### PR TITLE
Added Parceler support

### DIFF
--- a/dart-sample/pom.xml
+++ b/dart-sample/pom.xml
@@ -25,7 +25,17 @@
       <artifactId>butterknife</artifactId>
       <version>4.0.1</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.parceler</groupId>
+      <artifactId>parceler</artifactId>
+      <version>0.2.6</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.parceler</groupId>
+      <artifactId>parceler-api</artifactId>
+      <version>0.2.6</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/dart-sample/res/layout/activity_sample.xml
+++ b/dart-sample/res/layout/activity_sample.xml
@@ -50,4 +50,11 @@
       android:gravity="center"
       style="@android:style/TextAppearance.Large"
       />
+    <TextView
+      android:id="@+id/parcel_extra"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:gravity="center"
+      style="@android:style/TextAppearance.Large"
+      />
 </LinearLayout>

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/ExampleParcel.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/ExampleParcel.java
@@ -1,0 +1,19 @@
+package com.f2prateek.dart.example;
+
+import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
+
+@Parcel
+public class ExampleParcel {
+
+  String name;
+
+  @ParcelConstructor
+  public ExampleParcel(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.f2prateek.dart.Dart;
+import org.parceler.Parcels;
 
 public class MainActivity extends Activity {
 
@@ -40,6 +41,7 @@ public class MainActivity extends Activity {
     intent.putExtra(SampleActivity.EXTRA_STRING, "String");
     intent.putExtra(SampleActivity.EXTRA_INT, 4);
     intent.putExtra(SampleActivity.EXTRA_PARCELABLE, ComplexParcelable.random());
+    intent.putExtra(SampleActivity.EXTRA_PARCEL, Parcels.wrap(new ExampleParcel("Andy")));
     startActivity(intent);
   }
 }

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/SampleActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/SampleActivity.java
@@ -32,16 +32,19 @@ public class SampleActivity extends Activity {
   public static final String EXTRA_INT = "ExtraInt";
   public static final String EXTRA_PARCELABLE = "ExtraParcelable";
   public static final String EXTRA_OPTIONAL = "ExtraOptional";
+  public static final String EXTRA_PARCEL = "ExtraParcel";
 
   @InjectExtra(EXTRA_STRING) String stringExtra;
   @InjectExtra(EXTRA_INT) int intExtra;
   @InjectExtra(EXTRA_PARCELABLE) ComplexParcelable parcelableExtra;
+  @InjectExtra(EXTRA_PARCEL) ExampleParcel parcelExtra;
   @Optional @InjectExtra(EXTRA_OPTIONAL) String optionalExtra;
 
   @InjectView(R.id.string_extra) TextView stringText;
   @InjectView(R.id.int_extra) TextView intText;
   @InjectView(R.id.parcelable_extra) TextView parcelableText;
   @InjectView(R.id.optional_extra) TextView optionalText;
+  @InjectView(R.id.parcel_extra) TextView parcelText;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -55,5 +58,6 @@ public class SampleActivity extends Activity {
     intText.setText(String.valueOf(intExtra));
     parcelableText.setText(String.valueOf(parcelableExtra));
     optionalText.setText(String.valueOf(optionalExtra));
+    parcelText.setText(String.valueOf(parcelExtra.getName()));
   }
 }

--- a/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
+++ b/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.parceler.Parcels;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
@@ -30,12 +31,14 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class SampleActivityTest {
   @Test public void verifyExtrasInjection() {
     ComplexParcelable parcelable = ComplexParcelable.random();
+    ExampleParcel parcel = new ExampleParcel("andy");
 
     Intent intent = new Intent(Robolectric.application, SampleActivity.class);
     Bundle bundle = new Bundle();
     intent.putExtra(SampleActivity.EXTRA_STRING, "test");
     intent.putExtra(SampleActivity.EXTRA_INT, 4);
     intent.putExtra(SampleActivity.EXTRA_PARCELABLE, parcelable);
+    intent.putExtra(SampleActivity.EXTRA_PARCEL, Parcels.wrap(parcel));
     intent.putExtras(bundle);
 
     SampleActivity activity =
@@ -44,5 +47,6 @@ public class SampleActivityTest {
     assertThat(activity.stringExtra).isEqualTo("test");
     assertThat(activity.intExtra).isEqualTo(4);
     assertThat(activity.parcelableExtra).isEqualTo(parcelable);
+    assertThat(activity.parcelExtra).isEqualTo(parcel);
   }
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
@@ -95,8 +95,8 @@ final class ExtraInjector {
     }
   }
 
-  void addField(String key, String name, TypeMirror type, boolean required) {
-    getOrCreateExtraBinding(key).addFieldBinding(new FieldBinding(name, type, required));
+  void addField(String key, String name, TypeMirror type, boolean required, boolean parcel) {
+    getOrCreateExtraBinding(key).addFieldBinding(new FieldBinding(name, type, required, parcel));
   }
 
   void setParentInjector(String parentInjector) {
@@ -175,8 +175,13 @@ final class ExtraInjector {
 
     for (FieldBinding fieldBinding : fieldBindings) {
       builder.append("    target.").append(fieldBinding.getName()).append(" = ");
-      emitCast(builder, fieldBinding.getType());
-      builder.append("object;\n");
+
+      if (fieldBinding.isParcel()) {
+        builder.append("org.parceler.Parcels.unwrap((android.os.Parcelable)object);\n");
+      } else {
+        emitCast(builder, fieldBinding.getType());
+        builder.append("object;\n");
+      }
     }
   }
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/FieldBinding.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/FieldBinding.java
@@ -23,11 +23,13 @@ final class FieldBinding implements Binding {
   private final String name;
   private final TypeMirror type;
   private final boolean required;
+  private final boolean parcel;
 
-  FieldBinding(String name, TypeMirror type, boolean required) {
+  FieldBinding(String name, TypeMirror type, boolean required, boolean parcel) {
     this.name = name;
     this.type = type;
     this.required = required;
+    this.parcel = parcel;
   }
 
   public String getName() {
@@ -44,5 +46,9 @@ final class FieldBinding implements Binding {
 
   @Override public boolean isRequired() {
     return required;
+  }
+
+  public boolean isParcel() {
+    return parcel;
   }
 }


### PR DESCRIPTION
With just a couple additions Dart can support Parceler.  This means that Dart can read beans annotated with `@Parcel` if the Parceler library is included and used.

Included are the necessary changes, examples and tests.
