### PR TITLE
bugfix: NullPointerException prevented for optional extras

### DIFF
--- a/dart/src/main/java/com/f2prateek/dart/Dart.java
+++ b/dart/src/main/java/com/f2prateek/dart/Dart.java
@@ -173,7 +173,8 @@ public class Dart {
   public enum Finder {
     ACTIVITY {
       @Override public Object getExtra(Object source, String key) {
-        return ((Activity) source).getIntent().getExtras().get(key);
+          Bundle extras = ((Activity) source).getIntent().getExtras();
+          return extras != null ? extras.get(key) : null;
       }
     },
     FRAGMENT {


### PR DESCRIPTION
if there is no extra at all
