### PR TITLE
added default arguments for optional

### DIFF
--- a/dart/src/main/java/com/f2prateek/dart/Dart.java
+++ b/dart/src/main/java/com/f2prateek/dart/Dart.java
@@ -19,6 +19,7 @@ package com.f2prateek.dart;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import com.f2prateek.dart.internal.InjectExtraProcessor;
@@ -172,22 +173,27 @@ public class Dart {
    */
   public enum Finder {
     ACTIVITY {
-      @Override public Object getExtra(Object source, String key) {
-        return ((Activity) source).getIntent().getExtras().get(key);
+      @Override public Object getExtra(Object source, String key, Object defaultValue) {
+            Intent intent = ((Activity) source).getIntent();
+            if (intent.hasExtra(key)) {
+                return intent.getExtras().get(key);
+            } else {
+                return defaultValue;
+            }
       }
     },
     FRAGMENT {
-      @Override public Object getExtra(Object source, String key) {
+      @Override public Object getExtra(Object source, String key, Object defaultValue) {
         return ((Fragment) source).getArguments().get(key);
       }
     },
     BUNDLE {
-      @Override public Object getExtra(Object source, String key) {
+      @Override public Object getExtra(Object source, String key, Object defaultValue) {
         return ((Bundle) source).get(key);
       }
     };
 
-    public abstract Object getExtra(Object source, String key);
+    public abstract Object getExtra(Object source, String key, Object defaultValue);
   }
 
   public static class UnableToInjectException extends RuntimeException {

--- a/dart/src/main/java/com/f2prateek/dart/Optional.java
+++ b/dart/src/main/java/com/f2prateek/dart/Optional.java
@@ -17,6 +17,8 @@
 
 package com.f2prateek.dart;
 
+import android.os.Parcelable;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -32,4 +34,11 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  */
 @Retention(CLASS) @Target({ FIELD, METHOD })
 public @interface Optional {
+    String NULL = "com.f2prateek.dart.null";
+
+    boolean defaultBool() default false;
+    int defaultInt() default 0;
+    long defaultLong() default 0L;
+    String[] defaultStringArray() default {};
+    String defaultString() default NULL;
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/Binding.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/Binding.java
@@ -21,10 +21,6 @@ package com.f2prateek.dart.internal;
 interface Binding {
   /** A description of the binding in human readable form (e.g., "field 'foo'"). */
   String getDescription();
-
-  /**
-   * False if the {@link com.f2prateek.dart.Optional @Optional} annotation is present on the
-   * binding.
-   */
-  boolean isRequired();
+  /** details about the value if not given (required, if not defaults) **/
+  DefaultValue getDefault();
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/DefaultValue.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/DefaultValue.java
@@ -1,0 +1,74 @@
+package com.f2prateek.dart.internal;
+
+import com.f2prateek.dart.Optional;
+
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+public class DefaultValue {
+
+    public static final DefaultValue REQUIRED_NO_DEFAULT_ALLOWED = new DefaultValue();
+    private final boolean required;
+    private final Object value;
+
+    private DefaultValue() {
+        this.required = true;
+        this.value = null;
+    }
+
+    private DefaultValue(String s) {
+        this.required = false;
+        this.value = s;
+    }
+
+    private DefaultValue(int i) {
+        this.required = false;
+        this.value = i;
+    }
+
+    private DefaultValue(long l) {
+        this.required = false;
+        this.value = l;
+    }
+
+    private DefaultValue(boolean b) {
+        this.required = false;
+        this.value = b;
+    }
+
+    public DefaultValue(String[] strings) {
+        this.required = false;
+        this.value = strings;
+    }
+
+    public DefaultValue(Object o) {
+        this.required = false;
+        this.value = o;
+    }
+
+    public static DefaultValue from(TypeMirror type, Optional optional) {
+        switch (type.getKind()) {
+            case LONG: return new DefaultValue(optional.defaultLong());
+            case BOOLEAN: return new DefaultValue(optional.defaultBool());
+            case ARRAY: return new DefaultValue(optional.defaultStringArray());
+            case INT:
+            case DOUBLE:
+            case FLOAT:
+            case CHAR:
+                       return new DefaultValue(optional.defaultInt());
+        }
+        String s = optional.defaultString();
+        if (Optional.NULL.equals(s)) {
+            return new DefaultValue((String)null);
+        }
+        return new DefaultValue("\"" + optional.defaultString() + "\"");
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjection.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjection.java
@@ -40,13 +40,7 @@ final class ExtraInjection {
   }
 
   public List<Binding> getRequiredBindings() {
-    List<Binding> requiredBindings = new ArrayList<Binding>();
-    for (FieldBinding fieldBinding : fieldBindings) {
-      if (fieldBinding.isRequired()) {
-        requiredBindings.add(fieldBinding);
-      }
-    }
-    return requiredBindings;
+      return new ArrayList<Binding>(fieldBindings);
   }
 
   public void addFieldBinding(FieldBinding fieldBinding) {

--- a/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
@@ -95,7 +95,7 @@ final class ExtraInjector {
     }
   }
 
-  void addField(String key, String name, TypeMirror type, boolean required, boolean parcel) {
+  void addField(String key, String name, TypeMirror type, DefaultValue required, boolean parcel) {
     getOrCreateExtraBinding(key).addFieldBinding(new FieldBinding(name, type, required, parcel));
   }
 
@@ -149,12 +149,15 @@ final class ExtraInjector {
   }
 
   private void emitExtraInjection(StringBuilder builder, ExtraInjection injection) {
-    builder.append("    object = finder.getExtra(source, \"")
-        .append(injection.getKey())
-        .append("\");\n");
 
     List<Binding> requiredBindings = injection.getRequiredBindings();
-    if (!requiredBindings.isEmpty()) {
+    builder.append("    object = finder.getExtra(source, \"")
+        .append(injection.getKey())
+        .append("\", ")
+        .append((requiredBindings.isEmpty()) ? null : requiredBindings.get(0).getDefault().getValue())
+        .append(");\n");
+
+    if (!requiredBindings.isEmpty() && requiredBindings.get(0).getDefault().isRequired()) {
       builder.append("    if (object == null) {\n")
           .append("      throw new IllegalStateException(\"Required extra with key '")
           .append(injection.getKey())

--- a/dart/src/main/java/com/f2prateek/dart/internal/FieldBinding.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/FieldBinding.java
@@ -22,10 +22,10 @@ import javax.lang.model.type.TypeMirror;
 final class FieldBinding implements Binding {
   private final String name;
   private final TypeMirror type;
-  private final boolean required;
+  private final DefaultValue required;
   private final boolean parcel;
 
-  FieldBinding(String name, TypeMirror type, boolean required, boolean parcel) {
+  FieldBinding(String name, TypeMirror type, DefaultValue required, boolean parcel) {
     this.name = name;
     this.type = type;
     this.required = required;
@@ -44,11 +44,12 @@ final class FieldBinding implements Binding {
     return "field '" + name + "'";
   }
 
-  @Override public boolean isRequired() {
-    return required;
-  }
+    @Override
+    public DefaultValue getDefault() {
+        return required;
+    }
 
-  public boolean isParcel() {
+    public boolean isParcel() {
     return parcel;
   }
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
@@ -170,18 +170,26 @@ public final class InjectExtraProcessor extends AbstractProcessor {
     String name = element.getSimpleName().toString();
     String key = element.getAnnotation(InjectExtra.class).value();
     TypeMirror type = element.asType();
-    boolean required = element.getAnnotation(Optional.class) == null;
+    DefaultValue defaultValue = getDefault(type, element.getAnnotation(Optional.class));
     boolean parcel = isAnnotated(typeUtils.asElement(element.asType()), "org.parceler.Parcel");
 
     ExtraInjector extraInjector = getOrCreateTargetClass(targetClassMap, enclosingElement);
-    extraInjector.addField(key, name, type, required, parcel);
+    extraInjector.addField(key, name, type, defaultValue, parcel);
 
     // Add the type-erased version to the valid injection targets set.
     TypeMirror erasedTargetType = typeUtils.erasure(enclosingElement.asType());
     erasedTargetTypes.add(erasedTargetType);
   }
 
-  private boolean isAnnotated(Element element, String annotationName) {
+    private DefaultValue getDefault(TypeMirror type, Optional optional) {
+        if (optional == null) {
+            return DefaultValue.REQUIRED_NO_DEFAULT_ALLOWED;
+        } else {
+            return DefaultValue.from(type, optional);
+        }
+    }
+
+    private boolean isAnnotated(Element element, String annotationName) {
     if (element != null) {
       for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
         if (annotationMirror.getAnnotationType().asElement().toString().equals(annotationName)) {

--- a/dart/src/test/java/com/f2prateek/dart/internal/ExtraInjectorTest.java
+++ b/dart/src/test/java/com/f2prateek/dart/internal/ExtraInjectorTest.java
@@ -53,8 +53,9 @@ public class ExtraInjectorTest {
       return description;
     }
 
-    @Override public boolean isRequired() {
-      throw new AssertionError();
-    }
+      @Override
+      public DefaultValue getDefault() {
+          throw new AssertionError();
+      }
   }
 }

--- a/dart/src/test/java/com/f2prateek/dart/internal/InjectExtraTest.java
+++ b/dart/src/test/java/com/f2prateek/dart/internal/InjectExtraTest.java
@@ -44,7 +44,7 @@ public class InjectExtraTest {
             "import com.f2prateek.dart.Dart.Finder;", //
             "public class Test$$ExtraInjector {", //
             "  public static void inject(Finder finder, final test.Test target, Object source) {",
-            "    Object object;", "    object = finder.getExtra(source, \"key\");", //
+            "    Object object;", "    object = finder.getExtra(source, \"key\", null);", //
             "    if (object == null) {", //
             "      throw new IllegalStateException(\"Required extra with key 'key' for field 'extra' was not found. If this extra is optional add '@Optional' annotation.\");",
             "    }", //
@@ -79,7 +79,7 @@ public class InjectExtraTest {
             "import com.f2prateek.dart.Dart.Finder;", //
             "public class Test$$ExtraInjector {", //
             "  public static void inject(Finder finder, final test.Test target, Object source) {",
-            "    Object object;", "    object = finder.getExtra(source, \"key\");", //
+            "    Object object;", "    object = finder.getExtra(source, \"key\", null);", //
             "    if (object == null) {", //
             "      throw new IllegalStateException(\"Required extra with key 'key' for field 'extra1', field 'extra2', and field 'extra3' was not found. If this extra is optional add '@Optional' annotation.\");",
             "    }", //
@@ -131,7 +131,7 @@ public class InjectExtraTest {
             "public class Test$$ExtraInjector {", //
             "  public static void inject(Finder finder, final test.Test target, Object source) {",
             "    Object object;", //
-            "    object = finder.getExtra(source, \"key\");", //
+            "    object = finder.getExtra(source, \"key\", null);", //
             "    target.extra = (java.lang.String) object;", //
             "  }", //
             "}" //
@@ -145,7 +145,136 @@ public class InjectExtraTest {
         .generatesSources(expectedSource);
   }
 
-  @Test public void failsIfInPrivateClass() {
+    @Test public void optionalWithDefaultInt() {
+        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+                "package test;", //
+                "import android.app.Activity;", //
+                "import com.f2prateek.dart.InjectExtra;", //
+                "import com.f2prateek.dart.Optional;", //
+                "public class Test extends Activity {", //
+                "  @Optional(defaultInt=123) @InjectExtra(\"key\") int extra;", //
+                "}" //
+        ));
+
+        JavaFileObject expectedSource =
+                JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
+                        "package test;", //
+                        "import com.f2prateek.dart.Dart.Finder;", //
+                        "public class Test$$ExtraInjector {", //
+                        "  public static void inject(Finder finder, final test.Test target, Object source) {",
+                        "    Object object;", //
+                        "    object = finder.getExtra(source, \"key\", 123);", //
+                        "    target.extra = (java.lang.Integer) object;", //
+                        "  }", //
+                        "}" //
+                ));
+
+        ASSERT.about(javaSource())
+                .that(source)
+                .processedWith(dartProcessors())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(expectedSource);
+    }
+
+    @Test public void optionalWithDefaultBoolean() {
+        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+                "package test;", //
+                "import android.app.Activity;", //
+                "import com.f2prateek.dart.InjectExtra;", //
+                "import com.f2prateek.dart.Optional;", //
+                "public class Test extends Activity {", //
+                "  @Optional(defaultBool=true) @InjectExtra(\"key\") boolean extra;", //
+                "}" //
+        ));
+
+        JavaFileObject expectedSource =
+                JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
+                        "package test;", //
+                        "import com.f2prateek.dart.Dart.Finder;", //
+                        "public class Test$$ExtraInjector {", //
+                        "  public static void inject(Finder finder, final test.Test target, Object source) {",
+                        "    Object object;", //
+                        "    object = finder.getExtra(source, \"key\", true);", //
+                        "    target.extra = (java.lang.Boolean) object;", //
+                        "  }", //
+                        "}" //
+                ));
+
+        ASSERT.about(javaSource())
+                .that(source)
+                .processedWith(dartProcessors())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(expectedSource);
+    }
+
+    @Test public void optionalWithDefaultString() {
+        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+                "package test;", //
+                "import android.app.Activity;", //
+                "import com.f2prateek.dart.InjectExtra;", //
+                "import com.f2prateek.dart.Optional;", //
+                "public class Test extends Activity {", //
+                "  @Optional(defaultString=\"123\") @InjectExtra(\"key\") String extra;", //
+                "}" //
+        ));
+
+        JavaFileObject expectedSource =
+                JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
+                        "package test;", //
+                        "import com.f2prateek.dart.Dart.Finder;", //
+                        "public class Test$$ExtraInjector {", //
+                        "  public static void inject(Finder finder, final test.Test target, Object source) {",
+                        "    Object object;", //
+                        "    object = finder.getExtra(source, \"key\", \"123\");", //
+                        "    target.extra = (java.lang.String) object;", //
+                        "  }", //
+                        "}" //
+                ));
+
+        ASSERT.about(javaSource())
+                .that(source)
+                .processedWith(dartProcessors())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(expectedSource);
+    }
+
+    @Test public void optionalParcable() {
+        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+                "package test;", //
+                "import android.app.Activity;", //
+                "import android.os.Parcelable;", //
+                "import com.f2prateek.dart.InjectExtra;", //
+                "import com.f2prateek.dart.Optional;", //
+                "public class Test extends Activity {", //
+                "  @Optional @InjectExtra(\"key\") Parcelable extra;", //
+                "}" //
+        ));
+
+        JavaFileObject expectedSource =
+                JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
+                        "package test;", //
+                        "import com.f2prateek.dart.Dart.Finder;", //
+                        "public class Test$$ExtraInjector {", //
+                        "  public static void inject(Finder finder, final test.Test target, Object source) {",
+                        "    Object object;", //
+                        "    object = finder.getExtra(source, \"key\", null);", //
+                        "    target.extra = (android.os.Parcelable) object;", //
+                        "  }", //
+                        "}" //
+                ));
+
+        ASSERT.about(javaSource())
+                .that(source)
+                .processedWith(dartProcessors())
+                .compilesWithoutError()
+                .and()
+                .generatesSources(expectedSource);
+    }
+
+    @Test public void failsIfInPrivateClass() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
         "package test;", //
         "import android.app.Activity;", //
@@ -253,7 +382,7 @@ public class InjectExtraTest {
             "public class Test$$ExtraInjector {", //
             "  public static void inject(Finder finder, final test.Test target, Object source) {",
             "    Object object;", //
-            "    object = finder.getExtra(source, \"key\");", //
+            "    object = finder.getExtra(source, \"key\", null);", //
             "    if (object == null) {", //
             "      throw new IllegalStateException(\"Required extra with key 'key' for field 'extra' was not found. If this extra is optional add '@Optional' annotation.\");",
             "    }", //
@@ -270,7 +399,7 @@ public class InjectExtraTest {
             "  public static void inject(Finder finder, final test.TestOne target, Object source) {",
             "    test.Test$$ExtraInjector.inject(finder, target, source);", //
             "    Object object;", //
-            "    object = finder.getExtra(source, \"key\");", //
+            "    object = finder.getExtra(source, \"key\", null);", //
             "    if (object == null) {", //
             "      throw new IllegalStateException(\"Required extra with key 'key' for field 'extra1' was not found. If this extra is optional add '@Optional' annotation.\");",
             "    }", //
@@ -316,7 +445,7 @@ public class InjectExtraTest {
             "public class Test$$ExtraInjector {", //
             "  public static void inject(Finder finder, final test.Test target, Object source) {",
             "    Object object;", //
-            "    object = finder.getExtra(source, \"key\");", //
+            "    object = finder.getExtra(source, \"key\", null);", //
             "    if (object == null) {", //
             "      throw new IllegalStateException(\"Required extra with key 'key' for field 'extra' was not found. If this extra is optional add '@Optional' annotation.\");",
             "    }", //
@@ -332,7 +461,7 @@ public class InjectExtraTest {
             "  public static void inject(Finder finder, final test.TestOne target, Object source) {",
             "    test.Test$$ExtraInjector.inject(finder, target, source);", //
             "    Object object;", //
-            "    object = finder.getExtra(source, \"key\");", //
+            "    object = finder.getExtra(source, \"key\", null);", //
             "    if (object == null) {", //
             "      throw new IllegalStateException(\"Required extra with key 'key' for field 'extra1' was not found. If this extra is optional add '@Optional' annotation.\");",
             "    }", //


### PR DESCRIPTION
optional field should have default values.
Example
@Optional(defaultString = "NONE") @InjectExtra(ARG_TYPE) String type;

Else one starts with null checks and keep writing boilerplate code 
I had to create defaultString, defaultBool and so on as annotations does not allow a generic "Object".
I did not add a default for Parcables as defaults make more sense for primitives and especially strings
The "required" boolean moved now into this new class called DefaultValue. Added tests for the new types
