### PR TITLE
Issue #13: First approach

### DIFF
--- a/dart-sample/pom.xml
+++ b/dart-sample/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>org.parceler</groupId>
       <artifactId>parceler-api</artifactId>
-      <version>0.2.6</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/dart-sample/pom.xml
+++ b/dart-sample/pom.xml
@@ -30,12 +30,7 @@
     <dependency>
       <groupId>org.parceler</groupId>
       <artifactId>parceler</artifactId>
-      <version>0.2.6</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.parceler</groupId>
-      <artifactId>parceler-api</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/dart-sample/pom.xml
+++ b/dart-sample/pom.xml
@@ -69,7 +69,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+        <groupId>com.simpligility.maven.plugins</groupId>
         <artifactId>android-maven-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
@@ -23,7 +23,6 @@ import android.os.Bundle;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.f2prateek.dart.Dart;
-import org.parceler.Parcels;
 
 public class MainActivity extends Activity {
 
@@ -37,23 +36,13 @@ public class MainActivity extends Activity {
   }
 
   @OnClick(R.id.button) public void onLaunchButtonClick() {
-    Intent intent = SampleActivityIntentBuilder
+    Intent intent = new SampleActivityIntentBuilder(this)
         .withStringExtra("a string")
         .withIntExtra(4)
         .withParcelableExtra(ComplexParcelable.random())
-        .withParcelExra(new ExampleParcel("Andy"))
+        .withParcelExtra(new ExampleParcel("Andy"))
+        .withDefaultKeyExtra("defaultKeyExtra")
         .build();
-
-    intent.putExtra("defaultKeyExtra", "defaultKeyExtra");
-
-    /* Uncomment to use IntentBuilder
-    intent = new SampleActivityIntentBuilder(this).
-      withStringExtra("a string").
-      withIntExtra(4).
-      withParcelableExtra(ComplexParcelable.random()).
-      withParcelExtra(new ExampleParcel("Andy")).
-      withDefaultKeyExtra("defaultKeyExtra").build();
-    */
 
     startActivity(intent);
   }

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.f2prateek.dart.Dart;
+import org.parceler.Parcels;
 
 public class MainActivity extends Activity {
 
@@ -36,8 +37,14 @@ public class MainActivity extends Activity {
   }
 
   @OnClick(R.id.button) public void onLaunchButtonClick() {
-    Intent intent = SampleActivity.getLaunchIntent(this, "a string", 4, ComplexParcelable.random(),
-        new ExampleParcel("Andy"), "defaultKeyExtra");
+    Intent intent = SampleActivityIntentBuilder
+        .withStringExtra("a string")
+        .withIntExtra(4)
+        .withParcelableExtra(ComplexParcelable.random())
+        .withParcelExra(new ExampleParcel("Andy"))
+        .build();
+
+    intent.putExtra("defaultKeyExtra", "defaultKeyExtra");
 
     /* Uncomment to use IntentBuilder
     intent = new SampleActivityIntentBuilder(this).

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/MainActivity.java
@@ -38,6 +38,16 @@ public class MainActivity extends Activity {
   @OnClick(R.id.button) public void onLaunchButtonClick() {
     Intent intent = SampleActivity.getLaunchIntent(this, "a string", 4, ComplexParcelable.random(),
         new ExampleParcel("Andy"), "defaultKeyExtra");
+
+    /* Uncomment to use IntentBuilder
+    intent = new SampleActivityIntentBuilder(this).
+      withStringExtra("a string").
+      withIntExtra(4).
+      withParcelableExtra(ComplexParcelable.random()).
+      withParcelExtra(new ExampleParcel("Andy")).
+      withDefaultKeyExtra("defaultKeyExtra").build();
+    */
+
     startActivity(intent);
   }
 }

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/SampleActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/SampleActivity.java
@@ -18,8 +18,6 @@
 package com.f2prateek.dart.example;
 
 import android.app.Activity;
-import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.widget.TextView;
 import butterknife.ButterKnife;
@@ -27,7 +25,6 @@ import butterknife.InjectView;
 import com.f2prateek.dart.Dart;
 import com.f2prateek.dart.InjectExtra;
 import com.f2prateek.dart.Nullable;
-import org.parceler.Parcels;
 
 public class SampleActivity extends Activity {
   public static final String DEFAULT_EXTRA_VALUE = "a default value";

--- a/dart-sample/src/main/java/com/f2prateek/dart/example/SampleActivity.java
+++ b/dart-sample/src/main/java/com/f2prateek/dart/example/SampleActivity.java
@@ -55,17 +55,6 @@ public class SampleActivity extends Activity {
   @InjectView(R.id.parcel_extra) TextView parcelExtraTextView;
   @InjectView(R.id.default_extra) TextView defaultExtraTextView;
 
-  public static Intent getLaunchIntent(Context context, String string, int anInt,
-      ComplexParcelable complexParcelable, ExampleParcel exampleParcel, String defaultKey) {
-    Intent intent = new Intent(context, SampleActivity.class);
-    intent.putExtra(SampleActivity.EXTRA_STRING, string);
-    intent.putExtra(SampleActivity.EXTRA_INT, anInt);
-    intent.putExtra(SampleActivity.EXTRA_PARCELABLE, complexParcelable);
-    intent.putExtra(SampleActivity.EXTRA_PARCEL, Parcels.wrap(exampleParcel));
-    intent.putExtra("defaultKeyExtra", defaultKey);
-    return intent;
-  }
-
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_sample);

--- a/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
+++ b/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
@@ -20,6 +20,7 @@ package com.f2prateek.dart.example;
 import android.content.Intent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.parceler.Parcels;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -33,8 +34,14 @@ public class SampleActivityTest {
     ComplexParcelable parcelable = ComplexParcelable.random();
     ExampleParcel parcel = new ExampleParcel("andy");
 
-    Intent intent =
-        SampleActivity.getLaunchIntent(Robolectric.application, "test", 4, parcelable, parcel, "defaultKeyExtra");
+    Intent intent = SampleActivityIntentBuilder
+        .withStringExtra("test")
+        .withIntExtra(4)
+        .withParcelableExtra(complexParcelable)
+        .withParcelExra(Parcels.wrap(exampleParcel))
+        .build();
+
+    intent.putExtra("defaultKeyExtra", "defaultKeyExtra");
 
     SampleActivity activity =
         Robolectric.buildActivity(SampleActivity.class).withIntent(intent).create().get();

--- a/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
+++ b/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
@@ -18,6 +18,7 @@
 package com.f2prateek.dart.example;
 
 import android.content.Intent;
+import android.os.Parcelable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.parceler.Parcels;
@@ -34,14 +35,13 @@ public class SampleActivityTest {
     ComplexParcelable parcelable = ComplexParcelable.random();
     ExampleParcel parcel = new ExampleParcel("andy");
 
-    Intent intent = SampleActivityIntentBuilder
-        .withStringExtra("test")
-        .withIntExtra(4)
-        .withParcelableExtra(complexParcelable)
-        .withParcelExra(Parcels.wrap(exampleParcel))
-        .build();
-
-    intent.putExtra("defaultKeyExtra", "defaultKeyExtra");
+    Intent intent = new SampleActivityIntentBuilder(Robolectric.application)
+      .withStringExtra("test")
+      .withIntExtra(4)
+      .withParcelableExtra(parcelable)
+      .withParcelExtra(parcel)
+      .withDefaultKeyExtra("defaultKeyExtra")
+      .build();
 
     SampleActivity activity =
         Robolectric.buildActivity(SampleActivity.class).withIntent(intent).create().get();

--- a/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
+++ b/dart-sample/src/test/java/com/f2prateek/dart/example/SampleActivityTest.java
@@ -43,8 +43,11 @@ public class SampleActivityTest {
       .withDefaultKeyExtra("defaultKeyExtra")
       .build();
 
-    SampleActivity activity =
-        Robolectric.buildActivity(SampleActivity.class).withIntent(intent).create().get();
+    SampleActivity activity = Robolectric
+      .buildActivity(SampleActivity.class)
+      .withIntent(intent)
+      .create()
+      .get();
 
     assertThat(activity.stringExtra).isEqualTo("test");
     assertThat(activity.intExtra).isEqualTo(4);

--- a/dart/pom.xml
+++ b/dart/pom.xml
@@ -37,6 +37,12 @@
     </dependency>
 
     <dependency>
+        <groupId>com.squareup</groupId>
+        <artifactId>javapoet</artifactId>
+        <version>1.0.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.android</groupId>
       <artifactId>android</artifactId>
       <scope>provided</scope>

--- a/dart/pom.xml
+++ b/dart/pom.xml
@@ -35,6 +35,12 @@
       <artifactId>compile-testing</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.parceler</groupId>
+      <artifactId>parceler-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
 
     <dependency>
         <groupId>com.squareup</groupId>

--- a/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
@@ -189,4 +189,16 @@ final class ExtraInjector {
       }
     }
   }
+
+  public Map<String,ExtraInjection> getInjectionMap() {
+    return injectionMap;
+  }
+
+  public String getClassPackage() {
+    return classPackage;
+  }
+
+  public String getTargetClass() {
+    return targetClass;
+  }
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
@@ -190,7 +190,7 @@ final class ExtraInjector {
     }
   }
 
-  public Map<String,ExtraInjection> getInjectionMap() {
+  public Map<String, ExtraInjection> getInjectionMap() {
     return injectionMap;
   }
 

--- a/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
@@ -93,6 +93,7 @@ public final class InjectExtraProcessor extends AbstractProcessor {
         IntentBuilder intentBuilder = new IntentBuilder(extraInjector.getClassPackage(),
             typeElement.getSimpleName() + INTENT_BUILDER_SUFFIX, extraInjector.getTargetClass(),
             extraInjector.getInjectionMap());
+        System.out.println(intentBuilder.brewJava());
         JavaFileObject jfo = filer.createSourceFile(intentBuilder.getFqcn(), typeElement);
         Writer writer = jfo.openWriter();
         writer.write(intentBuilder.brewJava());

--- a/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
@@ -91,7 +91,7 @@ public final class InjectExtraProcessor extends AbstractProcessor {
       // Now write the IntentBuilder
       try {
         IntentBuilder intentBuilder = new IntentBuilder(extraInjector.getClassPackage(),
-            typeElement.getSimpleName()+INTENT_BUILDER_SUFFIX, extraInjector.getTargetClass(),
+            typeElement.getSimpleName() + INTENT_BUILDER_SUFFIX, extraInjector.getTargetClass(),
             extraInjector.getInjectionMap());
         JavaFileObject jfo = filer.createSourceFile(intentBuilder.getFqcn(), typeElement);
         Writer writer = jfo.openWriter();
@@ -99,7 +99,8 @@ public final class InjectExtraProcessor extends AbstractProcessor {
         writer.flush();
         writer.close();
       } catch (IOException e) {
-        error(typeElement, "Unable to write intent builder for type %s: %s", typeElement, e.getMessage());
+        error(typeElement, "Unable to write intent builder for type %s: %s", typeElement,
+            e.getMessage());
       }
     }
 

--- a/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/InjectExtraProcessor.java
@@ -51,6 +51,7 @@ import static javax.tools.Diagnostic.Kind.ERROR;
 
 public final class InjectExtraProcessor extends AbstractProcessor {
   public static final String SUFFIX = "$$ExtraInjector";
+  public static final String INTENT_BUILDER_SUFFIX = "IntentBuilder";
 
   private Elements elementUtils;
   private Types typeUtils;
@@ -85,6 +86,20 @@ public final class InjectExtraProcessor extends AbstractProcessor {
         writer.close();
       } catch (IOException e) {
         error(typeElement, "Unable to write injector for type %s: %s", typeElement, e.getMessage());
+      }
+
+      // Now write the IntentBuilder
+      try {
+        IntentBuilder intentBuilder = new IntentBuilder(extraInjector.getClassPackage(),
+            typeElement.getSimpleName()+INTENT_BUILDER_SUFFIX, extraInjector.getTargetClass(),
+            extraInjector.getInjectionMap());
+        JavaFileObject jfo = filer.createSourceFile(intentBuilder.getFqcn(), typeElement);
+        Writer writer = jfo.openWriter();
+        writer.write(intentBuilder.brewJava());
+        writer.flush();
+        writer.close();
+      } catch (IOException e) {
+        error(typeElement, "Unable to write intent builder for type %s: %s", typeElement, e.getMessage());
       }
     }
 

--- a/dart/src/main/java/com/f2prateek/dart/internal/IntentBuilder.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/IntentBuilder.java
@@ -1,0 +1,86 @@
+package com.f2prateek.dart.internal;
+
+import java.util.Iterator;
+import java.util.Map;
+
+final class IntentBuilder {
+  private final Map<String, ExtraInjection> injectionMap;
+  private final String classPackage;
+  private final String className;
+  private final String targetClass;
+
+  IntentBuilder(String classPackage, String className, String targetClass, Map<String, ExtraInjection> injectionMap) {
+    this.classPackage = classPackage;
+    this.className = className;
+    this.targetClass = targetClass;
+    this.injectionMap = injectionMap;
+  }
+
+  String getFqcn() {
+    return classPackage + "." + className;
+  }
+
+  String brewJava() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("// Generated code from Dart. Do not modify!\n");
+    builder.append("package ").append(classPackage).append(";\n\n");
+    builder.append("import android.content.Context;\n");
+    builder.append("import android.content.Intent;\n\n");
+
+    builder.append("public class ").append(className).append(" {\n");
+    builder.append("  private final Context context;\n\n");
+
+    createConstructor(builder);
+
+    for (ExtraInjection injection : injectionMap.values()) {
+      createSetter(injection, builder);
+    }
+
+    createBuildMethod(builder);
+
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  private void createSetter(ExtraInjection injection, StringBuilder builder) {
+    // TODO: Only doing first element.
+    // Not sure how usable is having several elements with the same key
+    Iterator<FieldBinding> iter = injection.getFieldBindings().iterator();
+    FieldBinding fb = iter.next();
+
+    builder.append("  private ").append(fb.getType()).append(" ").append(fb.getName()).append(";\n");
+    builder.append("  public ").append(className).append(" with").append(capitalize(fb.getName())).
+            append("(").append(fb.getType()).append(" ").append(fb.getName()).append(") {\n");
+    builder.append("    this.").append(fb.getName()).append(" = ").append(fb.getName()).append(";\n");
+    builder.append("    return this;\n");
+    builder.append("  }\n\n");
+  }
+
+  private String capitalize(String str) {
+    return str.substring(0,1).toUpperCase() + str.substring(1);
+  }
+
+  private void createConstructor(StringBuilder builder) {
+    builder.append("  public ").append(className).append("(Context context) {\n");
+    builder.append("    this.context = context;\n");
+    builder.append("  }\n\n");
+  }
+
+  private void createBuildMethod(StringBuilder builder) {
+    builder.append("  public Intent build() {\n");
+    builder.append("    Intent intent = new Intent(context, ").append(targetClass).append(".class);\n");
+
+    for (ExtraInjection injection : injectionMap.values()) {
+        // FIXME: Ugly. Iterating again over the same list
+        Iterator<FieldBinding> iter = injection.getFieldBindings().iterator();
+        FieldBinding fb = iter.next();
+        if (!fb.isParcel()) {
+            builder.append("    intent.putExtra(\"").append(injection.getKey()).append("\", ").
+                    append(fb.getName()).append(");\n");
+        }
+    }
+
+    builder.append("    return intent;\n");
+    builder.append("  }\n\n");
+  }
+}

--- a/dart/src/main/java/com/f2prateek/dart/internal/IntentBuilder.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/IntentBuilder.java
@@ -20,7 +20,8 @@ final class IntentBuilder {
   private final String className;
   private final String targetClass;
 
-  IntentBuilder(String classPackage, String className, String targetClass, Map<String, ExtraInjection> injectionMap) {
+  IntentBuilder(String classPackage, String className, String targetClass,
+        Map<String, ExtraInjection> injectionMap) {
     this.classPackage = classPackage;
     this.className = className;
     this.targetClass = targetClass;
@@ -50,7 +51,7 @@ final class IntentBuilder {
         .addStatement("Intent intent = new Intent(context, $N.class)", targetClass);
 
     for (ExtraInjection injection : injectionMap.values()) {
-      // TODO: Only doing first element.
+      // Only doing first element.
       // Not sure how usable is having several elements with the same key
       Iterator<FieldBinding> iter = injection.getFieldBindings().iterator();
       FieldBinding fb = iter.next();
@@ -82,7 +83,7 @@ final class IntentBuilder {
   }
 
   private String capitalize(String str) {
-    return str.substring(0,1).toUpperCase() + str.substring(1);
+    return str.substring(0, 1).toUpperCase() + str.substring(1);
   }
 
 }

--- a/dart/src/test/java/com/f2prateek/dart/internal/IntentBuilderTest.java
+++ b/dart/src/test/java/com/f2prateek/dart/internal/IntentBuilderTest.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright 2013 Jake Wharton
+ * Copyright 2014 Prateek Srivastava (@f2prateek)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.f2prateek.dart.internal;
+
+import com.google.common.base.Joiner;
+import com.google.testing.compile.JavaFileObjects;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+
+import static com.f2prateek.dart.internal.ProcessorTestUtilities.dartProcessors;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static org.truth0.Truth.ASSERT;
+
+public class IntentBuilderTest {
+
+  @Test public void injectingExtra() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test extends Activity {", //
+        "    @InjectExtra(\"key\") String extra;", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource =
+        JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+             "", //
+             "import android.content.Context;" , //
+             "import android.content.Intent;", //
+             "import java.lang.String;", //
+             "", //
+             "public class TestIntentBuilder {", //
+             "  private final Context context;", //
+             "", //
+             "  private String extra;", //
+             "", //
+             "  private boolean extraIsSet;", //
+             "", //
+             "  public TestIntentBuilder(Context context) {", //
+             "    this.context = context;", //
+             "  }", //
+             "", //
+             "  public TestIntentBuilder withExtra(String extra) {", //
+             "    this.extra = extra;", //
+             "    extraIsSet = true;", //
+             "    return this;", //
+             "  }", //
+             "", //
+             "  public Intent build() {", //
+             "    Intent intent = new Intent(context, test.Test.class);", //
+             "    if (extraIsSet) {", //
+             "      intent.putExtra(\"key\", extra);", //
+             "    } else {", //
+             "      throw new IllegalStateException(\"Parameter extra is mandatory\");", //
+             "    }", //
+             "    return intent;", //
+             "  }", //
+             "}" //
+      ));
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void injectingAllPrimitives() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test extends Activity {", //
+        "    @InjectExtra(\"key_bool\") boolean aBool;", //
+        "    @InjectExtra(\"key_byte\") byte aByte;", //
+        "    @InjectExtra(\"key_short\") short aShort;", //
+        "    @InjectExtra(\"key_int\") int anInt;", //
+        "    @InjectExtra(\"key_long\") long aLong;", //
+        "    @InjectExtra(\"key_char\") char aChar;", //
+        "    @InjectExtra(\"key_float\") float aFloat;", //
+        "    @InjectExtra(\"key_double\") double aDouble;", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource =
+        JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+            "", //
+            "import android.content.Context;", //
+            "import android.content.Intent;", //
+            "", //
+            "public class TestIntentBuilder {", //
+            "  private final Context context;", //
+            "", //
+            "  private boolean aBool;", //
+            "", //
+            "  private boolean aBoolIsSet;", //
+            "", //
+            "  private byte aByte;", //
+            "", //
+            "  private boolean aByteIsSet;", //
+            "", //
+            "  private short aShort;", //
+            "", //
+            "  private boolean aShortIsSet;", //
+            "", //
+            "  private int anInt;", //
+            "", //
+            "  private boolean anIntIsSet;", //
+            "", //
+            "  private long aLong;", //
+            "", //
+            "  private boolean aLongIsSet;", //
+            "", //
+            "  private char aChar;", //
+            "", //
+            "  private boolean aCharIsSet;", //
+            "", //
+            "  private float aFloat;", //
+            "", //
+            "  private boolean aFloatIsSet;", //
+            "", //
+            "  private double aDouble;", //
+            "", //
+            "  private boolean aDoubleIsSet;", //
+            "", //
+            "  public TestIntentBuilder(Context context) {", //
+            "    this.context = context;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withABool(boolean aBool) {", //
+            "    this.aBool = aBool;", //
+            "    aBoolIsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withAByte(byte aByte) {", //
+            "    this.aByte = aByte;", //
+            "    aByteIsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withAShort(short aShort) {", //
+            "    this.aShort = aShort;", //
+            "    aShortIsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withAnInt(int anInt) {", //
+            "    this.anInt = anInt;", //
+            "    anIntIsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withALong(long aLong) {", //
+            "    this.aLong = aLong;", //
+            "    aLongIsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withAChar(char aChar) {", //
+              "    this.aChar = aChar;", //
+              "    aCharIsSet = true;", //
+              "    return this;", //
+              "  }", //
+              "", //
+              "  public TestIntentBuilder withAFloat(float aFloat) {", //
+              "    this.aFloat = aFloat;", //
+              "    aFloatIsSet = true;", //
+              "    return this;", //
+              "  }", //
+              "", //
+              "  public TestIntentBuilder withADouble(double aDouble) {", //
+              "    this.aDouble = aDouble;", //
+              "    aDoubleIsSet = true;", //
+              "    return this;", //
+              "  }", //
+              "", //
+              "  public Intent build() {", //
+              "    Intent intent = new Intent(context, test.Test.class);", //
+              "    if (aBoolIsSet) {", //
+              "      intent.putExtra(\"key_bool\", aBool);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aBool is mandatory\");", //
+              "    }", //
+              "    if (aByteIsSet) {", //
+              "      intent.putExtra(\"key_byte\", aByte);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aByte is mandatory\");", //
+              "    }", //
+              "    if (aShortIsSet) {", //
+              "      intent.putExtra(\"key_short\", aShort);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aShort is mandatory\");", //
+              "    }", //
+              "    if (anIntIsSet) {", //
+              "      intent.putExtra(\"key_int\", anInt);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter anInt is mandatory\");", //
+              "    }", //
+              "    if (aLongIsSet) {", //
+              "      intent.putExtra(\"key_long\", aLong);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aLong is mandatory\");", //
+              "    }", //
+              "    if (aCharIsSet) {", //
+              "      intent.putExtra(\"key_char\", aChar);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aChar is mandatory\");", //
+              "    }", //
+              "    if (aFloatIsSet) {", //
+              "      intent.putExtra(\"key_float\", aFloat);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aFloat is mandatory\");", //
+              "    }", //
+              "    if (aDoubleIsSet) {", //
+              "      intent.putExtra(\"key_double\", aDouble);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter aDouble is mandatory\");", //
+              "    }", //
+              "    return intent;", //
+              "  }", //
+              "}" //
+        ));
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void oneFindPerKey() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test extends Activity {", //
+        "    @InjectExtra(\"key\") String extra1;", //
+        "    @InjectExtra(\"key\") String extra2;", //
+        "    @InjectExtra(\"key\") String extra3;", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource =
+        JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+            "", //
+            "import android.content.Context;", //
+            "import android.content.Intent;", //
+            "import java.lang.String;", //
+            "", //
+            "public class TestIntentBuilder {", //
+            "  private final Context context;", //
+            "", //
+            "  private String extra1;", //
+            "", //
+            "  private boolean extra1IsSet;", //
+            "", //
+            "  public TestIntentBuilder(Context context) {", //
+            "    this.context = context;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withExtra1(String extra1) {", //
+            "    this.extra1 = extra1;", //
+            "    extra1IsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public Intent build() {", //
+            "    Intent intent = new Intent(context, test.Test.class);", //
+            "    if (extra1IsSet) {", //
+            "      intent.putExtra(\"key\", extra1);", //
+            "    } else {", //
+            "      throw new IllegalStateException(\"Parameter extra1 is mandatory\");", //
+            "    }", //
+            "    return intent;", //
+            "  }", //
+            "}"  //
+        ));
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void defaultKey() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test extends Activity {", //
+        "    @InjectExtra String key;", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource =
+        JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+            "", //
+            "import android.content.Context;", //
+             "import android.content.Intent;", //
+             "import java.lang.String;", //
+             "", //
+             "public class TestIntentBuilder {", //
+             "  private final Context context;", //
+             "", //
+             "  private String key;", //
+             "", //
+             "  private boolean keyIsSet;", //
+             "", //
+             "  public TestIntentBuilder(Context context) {", //
+             "    this.context = context;", //
+             "  }", //
+             "", //
+             "  public TestIntentBuilder withKey(String key) {", //
+             "    this.key = key;", //
+             "    keyIsSet = true;", //
+             "    return this;", //
+             "  }", //
+             "", //
+             "  public Intent build() {", //
+             "    Intent intent = new Intent(context, test.Test.class);", //
+             "    if (keyIsSet) {", //
+             "      intent.putExtra(\"key\", key);", //
+             "    } else {", //
+             "      throw new IllegalStateException(\"Parameter key is mandatory\");", //
+             "    }", //
+             "    return intent;", //
+             "  }", //
+             "}" //
+        ));
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void superclass() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test extends Activity {", //
+        "    @InjectExtra(\"key\") String extra;", //
+        "}", //
+        "class TestOne extends Test {", //
+        "    @InjectExtra(\"key\") String extra1;", //
+        "}", //
+        "class TestTwo extends Test {", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource1 =
+        JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+            "", //
+            "import android.content.Context;", //
+            "import android.content.Intent;", //
+            "import java.lang.String;", //
+            "", //
+            "public class TestIntentBuilder {", //
+            "  private final Context context;", //
+            "", //
+            "  private String extra;", //
+            "", //
+            "  private boolean extraIsSet;", //
+            "", //
+            "  public TestIntentBuilder(Context context) {", //
+            "    this.context = context;", //
+            "  }", //
+            "", //
+            "  public TestIntentBuilder withExtra(String extra) {", //
+            "    this.extra = extra;", //
+            "    extraIsSet = true;", //
+            "    return this;", //
+            "  }", //
+            "", //
+            "  public Intent build() {", //
+            "    Intent intent = new Intent(context, test.Test.class);", //
+            "    if (extraIsSet) {", //
+            "      intent.putExtra(\"key\", extra);", //
+            "    } else {", //
+            "      throw new IllegalStateException(\"Parameter extra is mandatory\");", //
+            "    }", //
+            "    return intent;", //
+            "  }", //
+            "}" //
+        ));
+
+    JavaFileObject expectedSource2 =
+        JavaFileObjects.forSourceString("test/TestOneIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+             "", //
+             "import android.content.Context;", //
+             "import android.content.Intent;", //
+             "import java.lang.String;", //
+             "", //
+             "public class TestOneIntentBuilder {", //
+             "  private final Context context;", //
+             "", //
+             "  private String extra1;", //
+             "", //
+             "  private boolean extra1IsSet;", //
+             "", //
+             "  public TestOneIntentBuilder(Context context) {", //
+             "    this.context = context;", //
+             "  }", //
+             "", //
+             "  public TestOneIntentBuilder withExtra1(String extra1) {", //
+             "    this.extra1 = extra1;", //
+             "    extra1IsSet = true;", //
+             "    return this;", //
+             "  }", //
+             "", //
+             "  public Intent build() {", //
+             "    Intent intent = new Intent(context, test.TestOne.class);", //
+             "    if (extra1IsSet) {", //
+             "      intent.putExtra(\"key\", extra1);", //
+             "    } else {", //
+             "      throw new IllegalStateException(\"Parameter extra1 is mandatory\");", //
+             "    }", //
+             "    return intent;", //
+             "  }", //
+             "}" //
+        ));
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
+  }
+
+  @Test public void genericSuperclass() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test<T> extends Activity {", //
+        "    @InjectExtra(\"key\") String extra;", //
+        "}", //
+        "class TestOne extends Test<String> {", //
+        "    @InjectExtra(\"key\") String extra1;", //
+        "}", //
+        "class TestTwo extends Test<Object> {", //
+        "}" //
+    ));
+
+      JavaFileObject expectedSource1 =
+          JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+              "package test;", //
+              "", //
+              "import android.content.Context;", //
+              "import android.content.Intent;", //
+              "import java.lang.String;", //
+              "", //
+              "public class TestIntentBuilder {", //
+              "  private final Context context;", //
+              "", //
+              "  private String extra;", //
+              "", //
+              "  private boolean extraIsSet;", //
+              "", //
+              "  public TestIntentBuilder(Context context) {", //
+              "    this.context = context;", //
+              "  }", //
+              "", //
+              "  public TestIntentBuilder withExtra(String extra) {", //
+              "    this.extra = extra;", //
+              "    extraIsSet = true;", //
+              "    return this;", //
+              "  }", //
+              "", //
+              "  public Intent build() {", //
+              "    Intent intent = new Intent(context, test.Test.class);", //
+              "    if (extraIsSet) {", //
+              "      intent.putExtra(\"key\", extra);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter extra is mandatory\");", //
+              "    }", //
+              "    return intent;", //
+              "  }", //
+              "}" //
+          ));
+
+      JavaFileObject expectedSource2 =
+          JavaFileObjects.forSourceString("test/TestOneIntentBuilder", Joiner.on('\n').join( //
+              "package test;", //
+              "", //
+              "import android.content.Context;", //
+              "import android.content.Intent;", //
+              "import java.lang.String;", //
+              "", //
+              "public class TestOneIntentBuilder {", //
+              "  private final Context context;", //
+              "", //
+              "  private String extra1;", //
+              "", //
+              "  private boolean extra1IsSet;", //
+               "", //
+              "  public TestOneIntentBuilder(Context context) {", //
+              "    this.context = context;", //
+              "  }", //
+              "", //
+              "  public TestOneIntentBuilder withExtra1(String extra1) {", //
+              "    this.extra1 = extra1;", //
+              "    extra1IsSet = true;", //
+              "    return this;", //
+              "  }", //
+              "", //
+              "  public Intent build() {", //
+              "    Intent intent = new Intent(context, test.TestOne.class);", //
+              "    if (extra1IsSet) {", //
+              "      intent.putExtra(\"key\", extra1);", //
+              "    } else {", //
+              "      throw new IllegalStateException(\"Parameter extra1 is mandatory\");", //
+              "    }", //
+              "    return intent;", //
+              "  }", //
+              "}" //
+          ));
+
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource1, expectedSource2);
+  }
+}

--- a/dart/src/test/java/com/f2prateek/dart/internal/IntentBuilderTest.java
+++ b/dart/src/test/java/com/f2prateek/dart/internal/IntentBuilderTest.java
@@ -561,4 +561,76 @@ public class IntentBuilderTest {
         .and()
         .generatesSources(expectedSource1, expectedSource2);
   }
+
+    @Test public void injectingParcelExtra() {
+        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+             "package test;", //
+             "import android.app.Activity;", //
+             "import com.f2prateek.dart.InjectExtra;", //
+             "import org.parceler.Parcel;", //
+             "import org.parceler.ParcelConstructor;", //
+             "@Parcel", //
+             "class ExampleParcel {", //
+             "", //
+             "  String name;", //
+             "", //
+             "  @ParcelConstructor", //
+             "  public ExampleParcel(String name) {", //
+             "    this.name = name;", //
+             "  }", //
+             "", //
+             "  public String getName() {", //
+             "    return name;", //
+             "  }", //
+             "}", //
+             "public class Test extends Activity {", //
+             "    @InjectExtra(\"key\") ExampleParcel extra;", //
+             "}" //
+        ));
+
+        JavaFileObject expectedSource =
+            JavaFileObjects.forSourceString("test/TestIntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+             "", //
+             "import android.content.Context;", //
+             "import android.content.Intent;", //
+             "import android.os.Parcelable;", //
+             "", //
+             "public class TestIntentBuilder {", //
+             "  private final Context context;", //
+             "", //
+             "  private Parcelable extra;", //
+             "", //
+             "  private boolean extraIsSet;", //
+             "", //
+             "  public TestIntentBuilder(Context context) {", //
+             "    this.context = context;", //
+             "  }", //
+             "", //
+             "  public TestIntentBuilder withExtra(ExampleParcel extra) {", //
+             "    this.extra = org.parceler.Parcels.wrap(extra);", //
+             "    extraIsSet = true;", //
+             "    return this;", //
+             "  }", //
+             "", //
+             "  public Intent build() {", //
+             "    Intent intent = new Intent(context, test.Test.class);", //
+             "    if (extraIsSet) {", //
+             "      intent.putExtra(\"key\", extra);", //
+             "    } else {", //
+             "      throw new IllegalStateException(\"Parameter extra is mandatory\");", //
+             "    }", //
+             "    return intent;", //
+             "  }", //
+             "}" //
+            ));
+
+
+        ASSERT.about(javaSource())
+            .that(source)
+            .processedWith(dartProcessors())
+            .compilesWithoutError()
+            .and()
+            .generatesSources(expectedSource);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <java.version>1.6</java.version>
+    <java.version>1.7</java.version>
     <fest.version>2.0M10</fest.version>
     <android.version>4.1.1.4</android.version>
     <android.platform>16</android.platform>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <plugin>
           <groupId>com.simpligility.maven.plugins</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>4.1.1</version>
+          <version>4.2.1</version>
           <configuration>
             <sdk>
               <platform>${android.platform}</platform>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <robolectric.version>2.4</robolectric.version>
     <fest.android.version>1.0.7</fest.android.version>
     <compile-test.version>0.4</compile-test.version>
+    <parceler.version>0.2.6</parceler.version>
   </properties>
 
   <scm>
@@ -90,6 +91,12 @@
         <artifactId>compile-testing</artifactId>
         <version>${compile-test.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.parceler</groupId>
+        <artifactId>parceler-api</artifactId>
+        <version>${parceler.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
         <artifactId>parceler-api</artifactId>
         <version>${parceler.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.parceler</groupId>
+        <artifactId>parceler</artifactId>
+        <version>${parceler.version}</version>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This is just a first approach to issue #13. @stephanenicolas and I were discussing how to this for some time so I gave it a shot. It's far from finish but I would like to have some feedback. 
Instead of a factory I used the information gather by dart to create a separate class which works as an intent builder. 

In our app we are trying to get rid of the `IntentFactory` pattern and let every activity be responsible of it's API via a builder. We hope we can make Dart take care of that.

Some open questions:
 - It doesn't make a lot of sense of me that `ExtraInjection` has a  `Set<FieldBinding>` instead of a single one. Why is that?
 - I didn't handle the parcel case. I am not 100% sure how it should be done
 - @f2prateek, does it make sense to you for `IntentBuilder` to get information from `ExtraInjector`? I am not very happy with the getters added
 - I haven't found a good way to handle mandatory / optional parameters. Any recommendation? 
