### PR TITLE
Bundler

### DIFF
--- a/dart/src/main/java/com/f2prateek/dart/Bundler.java
+++ b/dart/src/main/java/com/f2prateek/dart/Bundler.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright 2014 Prateek Srivastava
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.f2prateek.dart;
+
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.util.SparseArray;
+import java.io.Serializable;
+import java.util.ArrayList;
+
+/**
+ * Fluent API for {@link android.os.Bundle}
+ * Usage: {@code Bundle delegate = new Bundler().put(....).put(....).get();}
+ */
+public class Bundler {
+
+  private final Bundle delegate;
+
+  /** Returns a bundler that delegates to a copy of the source bundle. */
+  public static Bundler copyOf(Bundle source) {
+    return create().putAll(source);
+  }
+
+  /** Returns a bundler that delegates to the source bundle. */
+  public static Bundler of(Bundle source) {
+    return new Bundler(source);
+  }
+
+  /** Creates a bundler instance. */
+  public static Bundler create() {
+    return new Bundler(new Bundle());
+  }
+
+  /** Constructs a new Bundler instance that delegates to {@code delegate}. */
+  private Bundler(Bundle delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * Inserts a Boolean value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a Boolean, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, boolean value) {
+    delegate.putBoolean(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a boolean array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a boolean array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, boolean[] value) {
+    delegate.putBooleanArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts an int value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value an int, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, int value) {
+    delegate.putInt(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts an int array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value an int array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, int[] value) {
+    delegate.putIntArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts an ArrayList<Integer> value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value an ArrayList<Integer> object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler putIntegerArrayList(String key, ArrayList<Integer> value) {
+    delegate.putIntegerArrayList(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a Bundle value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a Bundle object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, Bundle value) {
+    delegate.putBundle(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a byte value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value a byte
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, byte value) {
+    delegate.putByte(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a byte array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a byte array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, byte[] value) {
+    delegate.putByteArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a String value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a String, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, String value) {
+    delegate.putString(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a String array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a String array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, String[] value) {
+    delegate.putStringArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts an ArrayList<String> value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value an ArrayList<String> object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler putStringArrayList(String key, ArrayList<String> value) {
+    delegate.putStringArrayList(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a long value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value a long
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, long value) {
+    delegate.putLong(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a long array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a long array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, long[] value) {
+    delegate.putLongArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a float value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value a float
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, float value) {
+    delegate.putFloat(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a float array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a float array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, float[] value) {
+    delegate.putFloatArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a char value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value a char, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, char value) {
+    delegate.putChar(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a char array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a char array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, char[] value) {
+    delegate.putCharArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a CharSequence value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a CharSequence, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, CharSequence value) {
+    delegate.putCharSequence(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a CharSequence array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a CharSequence array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, CharSequence[] value) {
+    delegate.putCharSequenceArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts an ArrayList<CharSequence> value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value an ArrayList<CharSequence> object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler putCharSequenceArrayList(String key, ArrayList<CharSequence> value) {
+    delegate.putCharSequenceArrayList(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a double value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value a double
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, double value) {
+    delegate.putDouble(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a double array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a double array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, double[] value) {
+    delegate.putDoubleArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a Parcelable value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a Parcelable object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, Parcelable value) {
+    delegate.putParcelable(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts an array of Parcelable values into the mapping of the underlying Bundle,
+   * replacing any existing value for the given key.  Either key or value may
+   * be null.
+   *
+   * @param key a String, or null
+   * @param value an array of Parcelable objects, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, Parcelable[] value) {
+    delegate.putParcelableArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a List of Parcelable values into the mapping of the underlying Bundle,
+   * replacing any existing value for the given key.  Either key or value may
+   * be null.
+   *
+   * @param key a String, or null
+   * @param value an ArrayList of Parcelable objects, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler putParcelableArrayList(String key, ArrayList<? extends Parcelable> value) {
+    delegate.putParcelableArrayList(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a SparceArray of Parcelable values into the mapping of this
+   * Bundle, replacing any existing value for the given key.  Either key
+   * or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a SparseArray of Parcelable objects, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler putSparseParcelableArray(String key, SparseArray<? extends Parcelable> value) {
+    delegate.putSparseParcelableArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a short value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.
+   *
+   * @param key a String, or null
+   * @param value a short
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, short value) {
+    delegate.putShort(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a short array value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a short array object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, short[] value) {
+    delegate.putShortArray(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts a Serializable value into the mapping of the underlying Bundle, replacing
+   * any existing value for the given key.  Either key or value may be null.
+   *
+   * @param key a String, or null
+   * @param value a Serializable object, or null
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler put(String key, Serializable value) {
+    delegate.putSerializable(key, value);
+    return this;
+  }
+
+  /**
+   * Inserts all mappings from the given Bundle into the underlying Bundle.
+   *
+   * @param bundle a Bundle
+   * @return this bundler instance to chain method calls
+   */
+  public Bundler putAll(Bundle bundle) {
+    delegate.putAll(bundle);
+    return this;
+  }
+
+  /** Get a reference underlying delegate. */
+  public Bundle get() {
+    return delegate;
+  }
+
+  /** Get a copy of the underlying delegate. */
+  public Bundle copy() {
+    return new Bundle(delegate);
+  }
+}

--- a/dart/src/main/java/com/f2prateek/dart/Dart.java
+++ b/dart/src/main/java/com/f2prateek/dart/Dart.java
@@ -22,7 +22,7 @@ import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
-import com.f2prateek.dart.internal.InjectExtraProcessor;
+import com.f2prateek.dart.internal.ExtraInjector;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -155,7 +155,7 @@ public class Dart {
       return NO_OP;
     }
     try {
-      Class<?> injector = Class.forName(clsName + InjectExtraProcessor.SUFFIX);
+      Class<?> injector = Class.forName(clsName + ExtraInjector.INJECTOR_SUFFIX);
       inject = injector.getMethod("inject", Finder.class, cls, Object.class);
       if (debug) Log.d(TAG, "HIT: Class loaded injection class.");
     } catch (ClassNotFoundException e) {

--- a/dart/src/main/java/com/f2prateek/dart/internal/BundlerBuilder.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/BundlerBuilder.java
@@ -1,0 +1,113 @@
+package com.f2prateek.dart.internal;
+
+import java.util.Collection;
+import javax.lang.model.type.TypeMirror;
+
+public class BundlerBuilder {
+  public static final String BUNDLE_BUILDER_SUFFIX = "_Bundler";
+
+  private final InjectionTarget target;
+
+  public BundlerBuilder(InjectionTarget target) {
+    this.target = target;
+  }
+
+  private String builderClassName() {
+    return target.className + BUNDLE_BUILDER_SUFFIX;
+  }
+
+  String brewJava() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("// Generated code from Dart. Do not modify!\n");
+    builder.append("package ").append(target.classPackage).append(";\n\n");
+    builder.append("import android.os.Bundle;\n");
+    builder.append("import com.f2prateek.dart.Bundler;\n\n");
+    builder.append("public class ").append(builderClassName()).append(" {\n");
+    builder.append("  private final Bundler bundler = Bundler.create();\n\n");
+    emitSetters(builder);
+    emitGetter(builder);
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  private void emitGetter(StringBuilder builder) {
+    builder.append("  public Bundle get() {\n");
+    builder.append("    return bundler.get();\n");
+    builder.append("  }\n");
+  }
+
+  private void emitSetters(StringBuilder builder) {
+    // Loop over each extras injection and emit it.
+    for (ExtraInjection injection : target.injectionMap.values()) {
+      emitSetter(builder, injection);
+    }
+  }
+
+  private void emitSetter(StringBuilder builder, ExtraInjection injection) {
+    Collection<FieldBinding> fieldBindings = injection.getFieldBindings();
+    if (fieldBindings.isEmpty()) {
+      return;
+    }
+
+    // We can have the same extra key bound to multiple fields. We generate builders by key name,
+    // so we pick the first field binding and use it's type since they should all be the same
+    // anyway.
+    FieldBinding firstFieldBinding = fieldBindings.iterator().next();
+    TypeMirror extraType = firstFieldBinding.getType();
+    builder.append("  public ")
+        .append(builderClassName())
+        .append(' ')
+        .append(injection.getKey())
+        .append('(')
+        .append(getType(extraType))
+        .append(' ')
+        .append(injection.getKey())
+        .append(") {\n")
+        .append("    bundler.put(\"").append(injection.getKey()).append("\", ");
+    if (firstFieldBinding.isParcel()) {
+      builder.append("org.parceler.Parcels.wrap(").append(injection.getKey()).append(')');
+    } else {
+      builder.append(injection.getKey());
+    }
+    builder.append(");\n")
+        .append("    return this;\n")
+        .append("  }\n");
+  }
+
+  public String getFqcn() {
+    return target.getFqcn() + BUNDLE_BUILDER_SUFFIX;
+  }
+
+  static void emitCast(StringBuilder builder, TypeMirror fieldType) {
+    builder.append('(').append(getType(fieldType)).append(") ");
+  }
+
+  static String getType(TypeMirror type) {
+    if (type.getKind().isPrimitive()) {
+      // Get wrapper for primitive types
+      switch (type.getKind()) {
+        case BOOLEAN:
+          return "java.lang.Boolean";
+        case BYTE:
+          return "java.lang.Byte";
+        case SHORT:
+          return "java.lang.Short";
+        case INT:
+          return "java.lang.Integer";
+        case LONG:
+          return "java.lang.Long";
+        case CHAR:
+          return "java.lang.Character";
+        case FLOAT:
+          return "java.lang.Float";
+        case DOUBLE:
+          return "java.lang.Double";
+        default:
+          // Shouldn't happen
+          throw new RuntimeException();
+      }
+    } else {
+      return type.toString();
+    }
+  }
+}

--- a/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/ExtraInjector.java
@@ -14,27 +14,94 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.f2prateek.dart.internal;
 
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import javax.lang.model.type.TypeMirror;
 
-final class ExtraInjector {
-  private final Map<String, ExtraInjection> injectionMap =
-      new LinkedHashMap<String, ExtraInjection>();
-  private final String classPackage;
-  private final String className;
-  private final String targetClass;
-  private String parentInjector;
+public class ExtraInjector {
+  public static final String INJECTOR_SUFFIX = "$$ExtraInjector";
+  private final InjectionTarget target;
 
-  ExtraInjector(String classPackage, String className, String targetClass) {
-    this.classPackage = classPackage;
-    this.className = className;
-    this.targetClass = targetClass;
+  public ExtraInjector(InjectionTarget target) {
+    this.target = target;
+  }
+
+  String brewJava() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("// Generated code from Dart. Do not modify!\n");
+    builder.append("package ").append(target.classPackage).append(";\n\n");
+    builder.append("import com.f2prateek.dart.Dart.Finder;\n\n");
+    builder.append("public class ").append(target.className + INJECTOR_SUFFIX).append(" {\n");
+    emitInject(builder);
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  private void emitInject(StringBuilder builder) {
+    builder.append("  public static void inject(Finder finder, final ")
+        .append(target.targetClass)
+        .append(" target, Object source) {\n");
+
+    // Emit a call to the superclass injector, if any.
+    if (target.parentTarget != null) {
+      builder.append("    ")
+          .append(target.parentTarget + INJECTOR_SUFFIX)
+          .append(".inject(finder, target, source);\n\n");
+    }
+
+    // Local variable in which all extras will be temporarily stored.
+    builder.append("    Object object;\n");
+
+    // Loop over each extras injection and emit it.
+    for (ExtraInjection injection : target.injectionMap.values()) {
+      emitExtraInjection(builder, injection);
+    }
+
+    builder.append("  }\n");
+  }
+
+  private void emitExtraInjection(StringBuilder builder, ExtraInjection injection) {
+    builder.append("    object = finder.getExtra(source, \"")
+        .append(injection.getKey())
+        .append("\");\n");
+
+    List<Binding> requiredBindings = injection.getRequiredBindings();
+    if (!requiredBindings.isEmpty()) {
+      builder.append("    if (object == null) {\n")
+          .append("      throw new IllegalStateException(\"Required extra with key '")
+          .append(injection.getKey())
+          .append("' for ");
+      emitHumanDescription(builder, requiredBindings);
+      builder.append(" was not found. If this extra is optional add '@Nullable' annotation.\");\n")
+          .append("    }\n");
+      emitFieldBindings(builder, injection);
+    } else {
+      // an optional extra, wrap it in a check to keep original value, if any
+      builder.append("    if (object != null) {\n");
+      builder.append("  ");
+      emitFieldBindings(builder, injection);
+      builder.append("    }\n");
+    }
+  }
+
+  private void emitFieldBindings(StringBuilder builder, ExtraInjection injection) {
+    Collection<FieldBinding> fieldBindings = injection.getFieldBindings();
+    if (fieldBindings.isEmpty()) {
+      return;
+    }
+
+    for (FieldBinding fieldBinding : fieldBindings) {
+      builder.append("    target.").append(fieldBinding.getName()).append(" = ");
+
+      if (fieldBinding.isParcel()) {
+        builder.append("org.parceler.Parcels.unwrap((android.os.Parcelable) object);\n");
+      } else {
+        emitCast(builder, fieldBinding.getType());
+        builder.append("object;\n");
+      }
+    }
   }
 
   static void emitCast(StringBuilder builder, TypeMirror fieldType) {
@@ -95,98 +162,7 @@ final class ExtraInjector {
     }
   }
 
-  void addField(String key, String name, TypeMirror type, boolean required, boolean parcel) {
-    getOrCreateExtraBinding(key).addFieldBinding(new FieldBinding(name, type, required, parcel));
-  }
-
-  void setParentInjector(String parentInjector) {
-    this.parentInjector = parentInjector;
-  }
-
-  private ExtraInjection getOrCreateExtraBinding(String key) {
-    ExtraInjection extraInjection = injectionMap.get(key);
-    if (extraInjection == null) {
-      extraInjection = new ExtraInjection(key);
-      injectionMap.put(key, extraInjection);
-    }
-    return extraInjection;
-  }
-
-  String getFqcn() {
-    return classPackage + "." + className;
-  }
-
-  String brewJava() {
-    StringBuilder builder = new StringBuilder();
-    builder.append("// Generated code from Dart. Do not modify!\n");
-    builder.append("package ").append(classPackage).append(";\n\n");
-    builder.append("import com.f2prateek.dart.Dart.Finder;\n\n");
-    builder.append("public class ").append(className).append(" {\n");
-    emitInject(builder);
-    builder.append("}\n");
-    return builder.toString();
-  }
-
-  private void emitInject(StringBuilder builder) {
-    builder.append("  public static void inject(Finder finder, final ")
-        .append(targetClass)
-        .append(" target, Object source) {\n");
-
-    // Emit a call to the superclass injector, if any.
-    if (parentInjector != null) {
-      builder.append("    ").append(parentInjector).append(".inject(finder, target, source);\n\n");
-    }
-
-    // Local variable in which all extras will be temporarily stored.
-    builder.append("    Object object;\n");
-
-    // Loop over each extras injection and emit it.
-    for (ExtraInjection injection : injectionMap.values()) {
-      emitExtraInjection(builder, injection);
-    }
-
-    builder.append("  }\n");
-  }
-
-  private void emitExtraInjection(StringBuilder builder, ExtraInjection injection) {
-    builder.append("    object = finder.getExtra(source, \"")
-        .append(injection.getKey())
-        .append("\");\n");
-
-    List<Binding> requiredBindings = injection.getRequiredBindings();
-    if (!requiredBindings.isEmpty()) {
-      builder.append("    if (object == null) {\n")
-          .append("      throw new IllegalStateException(\"Required extra with key '")
-          .append(injection.getKey())
-          .append("' for ");
-      emitHumanDescription(builder, requiredBindings);
-      builder.append(" was not found. If this extra is optional add '@Nullable' annotation.\");\n")
-          .append("    }\n");
-      emitFieldBindings(builder, injection);
-    } else {
-      // an optional extra, wrap it in a check to keep original value, if any
-      builder.append("    if (object != null) {\n");
-      builder.append("  ");
-      emitFieldBindings(builder, injection);
-      builder.append("    }\n");
-    }
-  }
-
-  private void emitFieldBindings(StringBuilder builder, ExtraInjection injection) {
-    Collection<FieldBinding> fieldBindings = injection.getFieldBindings();
-    if (fieldBindings.isEmpty()) {
-      return;
-    }
-
-    for (FieldBinding fieldBinding : fieldBindings) {
-      builder.append("    target.").append(fieldBinding.getName()).append(" = ");
-
-      if (fieldBinding.isParcel()) {
-        builder.append("org.parceler.Parcels.unwrap((android.os.Parcelable) object);\n");
-      } else {
-        emitCast(builder, fieldBinding.getType());
-        builder.append("object;\n");
-      }
-    }
+  public String getFqcn() {
+    return target.getFqcn() + INJECTOR_SUFFIX;
   }
 }

--- a/dart/src/main/java/com/f2prateek/dart/internal/InjectionTarget.java
+++ b/dart/src/main/java/com/f2prateek/dart/internal/InjectionTarget.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013 Jake Wharton
+ * Copyright 2014 Prateek Srivastava (@f2prateek)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.f2prateek.dart.internal;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.lang.model.type.TypeMirror;
+
+final class InjectionTarget {
+  final Map<String, ExtraInjection> injectionMap = new LinkedHashMap<String, ExtraInjection>();
+  final String classPackage;
+  final String className;
+  final String targetClass;
+  String parentTarget;
+
+  InjectionTarget(String classPackage, String className, String targetClass) {
+    this.classPackage = classPackage;
+    this.className = className;
+    this.targetClass = targetClass;
+  }
+
+  void addField(String key, String name, TypeMirror type, boolean required, boolean parcel) {
+    getOrCreateExtraBinding(key).addFieldBinding(new FieldBinding(name, type, required, parcel));
+  }
+
+  void setParentTarget(String parentTarget) {
+    this.parentTarget = parentTarget;
+  }
+
+  private ExtraInjection getOrCreateExtraBinding(String key) {
+    ExtraInjection extraInjection = injectionMap.get(key);
+    if (extraInjection == null) {
+      extraInjection = new ExtraInjection(key);
+      injectionMap.put(key, extraInjection);
+    }
+    return extraInjection;
+  }
+
+  String getFqcn() {
+    return classPackage + "." + className;
+  }
+}

--- a/dart/src/test/java/com/f2prateek/dart/internal/InjectExtraTest.java
+++ b/dart/src/test/java/com/f2prateek/dart/internal/InjectExtraTest.java
@@ -38,7 +38,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    JavaFileObject expectedSource =
+    JavaFileObject injectorSource =
         JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
             "package test;", //
             "import com.f2prateek.dart.Dart.Finder;", //
@@ -53,12 +53,29 @@ public class InjectExtraTest {
             "}" //
         ));
 
+    JavaFileObject builderSource =
+        JavaFileObjects.forSourceString("test/Test_Bundler", Joiner.on('\n').join( //
+            "package test;", //
+            "import android.os.Bundle;", //
+            "import com.f2prateek.dart.Bundler;", //
+            "public class Test_Bundler {", //
+            "  private final Bundler bundler = Bundler.create();", //
+            "  public Test_Bundler key(java.lang.String key) {", //
+            "    bundler.put(\"key\", key);", //
+            "    return this;", //
+            "  }", //
+            "  public Bundle get() {", //
+            "    return bundler.get()", //
+            "  }", //
+            "}" //
+        ));
+
     ASSERT.about(javaSource())
         .that(source)
         .processedWith(dartProcessors())
         .compilesWithoutError()
         .and()
-        .generatesSources(expectedSource);
+        .generatesSources(injectorSource, builderSource);
   }
 
   @Test public void injectingAllPrimitives() {
@@ -78,7 +95,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    JavaFileObject expectedSource =
+    JavaFileObject injectorSource =
         JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
             "package test;", //
             "import com.f2prateek.dart.Dart.Finder;", //
@@ -129,12 +146,57 @@ public class InjectExtraTest {
             "}" //
         ));
 
+      JavaFileObject builderSource =
+          JavaFileObjects.forSourceString("test/Test_Bundler", Joiner.on('\n').join( //
+              "package test;", //
+              "import android.os.Bundle;", //
+              "import com.f2prateek.dart.Bundler;", //
+              "public class Test_Bundler {", //
+              "  private final Bundler bundler = Bundler.create();", //
+              "  public Test_Bundler key_bool(java.lang.Boolean key_bool) {", //
+              "    bundler.put(\"key_bool\", key_bool);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_byte(java.lang.Byte key_byte) {", //
+              "    bundler.put(\"key_byte\", key_byte);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_short(java.lang.Short key_short) {", //
+              "    bundler.put(\"key_short\", key_short);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_int(java.lang.Integer key_int) {", //
+              "    bundler.put(\"key_int\", key_int);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_long(java.lang.Long key_long) {", //
+              "    bundler.put(\"key_long\", key_long);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_char(java.lang.Character key_char) {", //
+              "    bundler.put(\"key_char\", key_char);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_float(java.lang.Float key_float) {", //
+              "    bundler.put(\"key_float\", key_float);", //
+              "    return this;", //
+              "  }", //
+              "  public Test_Bundler key_double(java.lang.Double key_double) {", //
+              "    bundler.put(\"key_double\", key_double);", //
+              "    return this;", //
+              "  }", //
+              "  public Bundle get() {", //
+              "    return bundler.get()", //
+              "  }", //
+              "}" //
+          ));
+
     ASSERT.about(javaSource())
         .that(source)
         .processedWith(dartProcessors())
         .compilesWithoutError()
         .and()
-        .generatesSources(expectedSource);
+        .generatesSources(injectorSource, builderSource);
   }
 
   @Test public void oneFindPerKey() {
@@ -256,39 +318,39 @@ public class InjectExtraTest {
         .generatesSources(expectedSource);
   }
 
-    @Test public void nullable() {
-        JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+  @Test public void nullable() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "import com.f2prateek.dart.Nullable;", //
+        "public class Test extends Activity {", //
+        "  @Nullable @InjectExtra(\"key\") String extra;", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource =
+        JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
             "package test;", //
-            "import android.app.Activity;", //
-            "import com.f2prateek.dart.InjectExtra;", //
-            "import com.f2prateek.dart.Nullable;", //
-            "public class Test extends Activity {", //
-            "  @Nullable @InjectExtra(\"key\") String extra;", //
+            "import com.f2prateek.dart.Dart.Finder;", //
+            "public class Test$$ExtraInjector {", //
+            "  public static void inject(Finder finder, final test.Test target, Object source) {",
+            "    Object object;", //
+            "    object = finder.getExtra(source, \"key\");", //
+            "    if (object != null) {", //
+            "    target.extra = (java.lang.String) object;", //
+            "    }", //
+            "  }", //
             "}" //
         ));
 
-        JavaFileObject expectedSource =
-            JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
-                "package test;", //
-                "import com.f2prateek.dart.Dart.Finder;", //
-                "public class Test$$ExtraInjector {", //
-                "  public static void inject(Finder finder, final test.Test target, Object source) {",
-                "    Object object;", //
-                "    object = finder.getExtra(source, \"key\");", //
-                "    if (object != null) {", //
-                "    target.extra = (java.lang.String) object;", //
-                "    }", //
-                "  }", //
-                "}" //
-            ));
-
-        ASSERT.about(javaSource())
-            .that(source)
-            .processedWith(dartProcessors())
-            .compilesWithoutError()
-            .and()
-            .generatesSources(expectedSource);
-    }
+    ASSERT.about(javaSource())
+        .that(source)
+        .processedWith(dartProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
 
   @Test public void failsIfInPrivateClass() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //


### PR DESCRIPTION
This adss a convenience class `Bundler` that makes it easy to chain
calls while creating a Bundle and provides a more fluent API.
It also generates a class Foo_Bundler that adds type safe methods to
insert values into a bundle (for construction) for all keys annotated
with `@InjectExtra`.

Future Improvements:
* Use Bundle instead of Bundler. I've used Bundler to simplify the
  current implementation, but this approach will allocated 2 objects.
* Add a Fragment and Activity specific Bundler that adds some more
  convenience methods.

Similar to #33 but is simplified to generate a type safe builder for any class that has an `@InjectExtra` annotation. 

#33 only generates a class that will build an `Intent` for activities. Instead this generates a class that will build a Bundle (which can be used by Fragments, Activities, Services, POJOs).