### PR TITLE
Fixes in RC 1 --> RC 2

### DIFF
--- a/dart-processor/src/main/java/com/f2prateek/dart/processor/ExtraInjectionGenerator.java
+++ b/dart-processor/src/main/java/com/f2prateek/dart/processor/ExtraInjectionGenerator.java
@@ -26,6 +26,7 @@ import com.f2prateek.dart.common.InjectionTarget;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.Collection;
 import java.util.List;
@@ -124,7 +125,7 @@ public class ExtraInjectionGenerator extends BaseGenerator {
   }
 
   private void emitCast(MethodSpec.Builder builder, TypeMirror fieldType) {
-    builder.addCode("($T) ", ClassName.bestGuess(getType(fieldType)));
+    builder.addCode("($T) ", TypeName.get(fieldType));
   }
 
   //TODO add android annotations dependency to get that annotation plus others.

--- a/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraTest.java
+++ b/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraTest.java
@@ -84,69 +84,53 @@ public class InjectExtraTest {
     JavaFileObject injectorSource =
         JavaFileObjects.forSourceString("test/Test$$ExtraInjector", Joiner.on('\n').join( //
             "package test;", //
-            "import com.f2prateek.dart.Dart;", //
-            "import java.lang.Boolean;", //
-            "import java.lang.Byte;", //
-            "import java.lang.Character;", //
-            "import java.lang.Double;", //
-            "import java.lang.Float;", //
-            "import java.lang.Integer;", //
-            "import java.lang.Long;", //
-            "import java.lang.Object;", //
-            "import java.lang.Short;", //
-            "public class Test$$ExtraInjector {", //
-            "  public static void inject(Dart.Finder finder, Test target, Object source) {", //
-            "    Object object;", //
-            "    object = finder.getExtra(source, \"key_bool\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_bool' for field 'aBool' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aBool = (Boolean) object;", //
-            "    object = finder.getExtra(source, \"key_byte\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_byte' for field 'aByte' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aByte = (Byte) object;", //
-            "    object = finder.getExtra(source, \"key_short\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_short' for field 'aShort' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aShort = (Short) object;", //
-            "    object = finder.getExtra(source, \"key_int\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_int' for field 'anInt' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.anInt = (Integer) object;", //
-            "    object = finder.getExtra(source, \"key_long\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_long' for field 'aLong' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aLong = (Long) object;", //
-            "    object = finder.getExtra(source, \"key_char\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_char' for field 'aChar' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aChar = (Character) object;", //
-            "    object = finder.getExtra(source, \"key_float\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_float' for field 'aFloat' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aFloat = (Float) object;", //
-            "    object = finder.getExtra(source, \"key_double\");", //
-            "    if (object == null) {", //
-            "      throw new IllegalStateException(\"Required extra with key 'key_double' for field 'aDouble' was not found. If this extra is optional add '@Nullable' annotation.\");",
-            //
-            "    }", //
-            "    target.aDouble = (Double) object;", //
-            "  }", //
-            "}" //
+                "import com.f2prateek.dart.Dart;", //
+                "import java.lang.Object;", //
+                "public class Test$$ExtraInjector {", //
+                "  public static void inject(Dart.Finder finder, Test target, Object source) {", //
+                "    Object object;", //
+                "    object = finder.getExtra(source, \"key_bool\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_bool' for field 'aBool' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aBool = (boolean) object;", //
+                "    object = finder.getExtra(source, \"key_byte\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_byte' for field 'aByte' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aByte = (byte) object;", //
+                "    object = finder.getExtra(source, \"key_short\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_short' for field 'aShort' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aShort = (short) object;", //
+                "    object = finder.getExtra(source, \"key_int\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_int' for field 'anInt' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.anInt = (int) object;", //
+                "    object = finder.getExtra(source, \"key_long\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_long' for field 'aLong' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aLong = (long) object;", //
+                "    object = finder.getExtra(source, \"key_char\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_char' for field 'aChar' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aChar = (char) object;", //
+                "    object = finder.getExtra(source, \"key_float\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_float' for field 'aFloat' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aFloat = (float) object;", //
+                "    object = finder.getExtra(source, \"key_double\");", //
+                "    if (object == null) {", //
+                "      throw new IllegalStateException(\"Required extra with key 'key_double' for field 'aDouble' was not found. If this extra is optional add '@Nullable' annotation.\");", //
+                "    }", //
+                "    target.aDouble = (double) object;", //
+                "  }", //
+                "}" //
         ));
 
     ASSERT.about(javaSource())

--- a/dart-processor/src/test/java/com/f2prateek/dart/processor/ProcessorTestUtilities.java
+++ b/dart-processor/src/test/java/com/f2prateek/dart/processor/ProcessorTestUtilities.java
@@ -17,7 +17,6 @@
 
 package com.f2prateek.dart.processor;
 
-import com.f2prateek.dart.processor.InjectExtraProcessor;
 import java.util.Arrays;
 import javax.annotation.processing.Processor;
 

--- a/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/HensonNavigatorGenerator.java
+++ b/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/HensonNavigatorGenerator.java
@@ -1,6 +1,5 @@
 package com.f2prateek.dart.henson.processor;
 
-import android.content.Context;
 import com.f2prateek.dart.InjectExtra;
 import com.f2prateek.dart.common.BaseGenerator;
 import com.f2prateek.dart.common.InjectionTarget;
@@ -20,6 +19,12 @@ import javax.lang.model.element.Modifier;
  * This generator creates the Henson class.
  * The intent builders are created by {@link IntentBuilderGenerator}.
  * @see {@link com.f2prateek.dart.henson.Henson} to use this code at runtime.
+ * Note: Due to the fact that gradle uses a different classpath to invoke
+ * an annotation processor (it doesn't use the same classpath as the one that is used
+ * to compile the classes to be compiled), this we can't use android classes in a generator.
+ * We should always reference them indirectly via string, not using direct references to types
+ * (i.e. not Intent.class but ClassName.get("android.content", "Intent"))
+ * See https://github.com/johncarl81/parceler/issues/11
  */
 public class HensonNavigatorGenerator extends BaseGenerator {
   public static final String HENSON_NAVIGATOR_CLASS_NAME = "Henson";
@@ -67,10 +72,11 @@ public class HensonNavigatorGenerator extends BaseGenerator {
         TypeSpec.classBuilder(WITH_CONTEXT_SET_STATE_CLASS_NAME)
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
     withContextSetStateBuilder.addField(
-        FieldSpec.builder(Context.class, "context", Modifier.PRIVATE).build());
+        FieldSpec.builder(ClassName.get("android.content", "Context"),
+            "context", Modifier.PRIVATE).build());
     withContextSetStateBuilder.addMethod(MethodSpec.constructorBuilder()
         .addModifiers(Modifier.PRIVATE)
-        .addParameter(Context.class, "context")
+        .addParameter(ClassName.get("android.content", "Context"), "context")
         .addStatement("this.context = context")
         .build());
     //separate required extras from optional extras and sort both sublists.
@@ -89,7 +95,7 @@ public class HensonNavigatorGenerator extends BaseGenerator {
         ClassName.get(packageName, HENSON_NAVIGATOR_CLASS_NAME, WITH_CONTEXT_SET_STATE_CLASS_NAME);
     MethodSpec.Builder gotoMethodBuilder = MethodSpec.methodBuilder("with")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addParameter(Context.class, "context")
+        .addParameter(ClassName.get("android.content", "Context"), "context")
         .returns(withContextSetStateClassName)
         .addStatement("return new $L(context)", withContextSetStateClassName);
     builder.addMethod(gotoMethodBuilder.build());

--- a/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/IntentBuilderGenerator.java
+++ b/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/IntentBuilderGenerator.java
@@ -9,6 +9,7 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -215,7 +216,7 @@ public class IntentBuilderGenerator extends BaseGenerator {
     MethodSpec.Builder setterBuilder = MethodSpec.methodBuilder(injection.getKey())
         .addModifiers(Modifier.PUBLIC)
         .returns(ClassName.bestGuess(nextStateClassName))
-        .addParameter(ClassName.bestGuess(getType(extraType)), injection.getKey())
+        .addParameter(TypeName.get(extraType), injection.getKey())
         .addStatement("bundler.put($S,$L)", injection.getKey(), value);
 
     if (isOptional) {

--- a/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/IntentBuilderGenerator.java
+++ b/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/IntentBuilderGenerator.java
@@ -1,7 +1,5 @@
 package com.f2prateek.dart.henson.processor;
 
-import android.content.Context;
-import android.content.Intent;
 import com.f2prateek.dart.common.BaseGenerator;
 import com.f2prateek.dart.common.ExtraInjection;
 import com.f2prateek.dart.common.FieldBinding;
@@ -28,6 +26,13 @@ import javax.lang.model.type.TypeMirror;
  * created by {@link HensonNavigatorGenerator}.
  *
  * @see {@link com.f2prateek.dart.henson.Henson} to use this code at runtime.
+ * Note: Due to the fact that gradle uses a different classpath to invoke
+ * an annotation processor (it doesn't use the same classpath as the one that is used
+ * to compile the classes to be compiled), this we can't use android classes in a generator.
+ * We should always reference them indirectly via string, not using direct references to types
+ * (i.e. not Intent.class but ClassName.get("android.content", "Intent"))
+ * See https://github.com/johncarl81/parceler/issues/11
+
  */
 public class IntentBuilderGenerator extends BaseGenerator {
   public static final String BUNDLE_BUILDER_SUFFIX = "$$IntentBuilder";
@@ -61,7 +66,7 @@ public class IntentBuilderGenerator extends BaseGenerator {
 
   private void emitFields(TypeSpec.Builder intentBuilderTypeBuilder) {
     FieldSpec.Builder intentFieldBuilder =
-        FieldSpec.builder(Intent.class, "intent", Modifier.PRIVATE);
+        FieldSpec.builder(ClassName.get("android.content", "Intent"), "intent", Modifier.PRIVATE);
     intentBuilderTypeBuilder.addField(intentFieldBuilder.build());
     FieldSpec.Builder bundlerFieldBuilder =
         FieldSpec.builder(Bundler.class, "bundler", Modifier.PRIVATE);
@@ -72,7 +77,7 @@ public class IntentBuilderGenerator extends BaseGenerator {
   private void emitConstructor(TypeSpec.Builder intentBuilderTypeBuilder) {
     MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder()
         .addModifiers(Modifier.PUBLIC)
-        .addParameter(Context.class, "context")
+        .addParameter(ClassName.get("android.content", "Context"), "context")
         .addStatement("intent = new Intent(context, $L)", target.className + ".class");
     intentBuilderTypeBuilder.addMethod(constructorBuilder.build());
   }
@@ -118,7 +123,7 @@ public class IntentBuilderGenerator extends BaseGenerator {
   private void emitBuildMethod(TypeSpec.Builder builder) {
     MethodSpec.Builder getBuilder = MethodSpec.methodBuilder("build")
         .addModifiers(Modifier.PUBLIC)
-        .returns(Intent.class)
+        .returns(ClassName.get("android.content", "Intent"))
         .addStatement("intent.putExtras(bundler.get())")
         .addStatement("return intent");
     builder.addMethod(getBuilder.build());

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorTest.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorTest.java
@@ -91,76 +91,68 @@ public class IntentBuilderGeneratorTest {
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString("test/Test$$IntentBuilder", Joiner.on('\n').join( //
             "package test;", //
-            "import android.content.Context;", //
-            "import android.content.Intent;", //
-            "import com.f2prateek.dart.henson.Bundler;", //
-            "import java.lang.Boolean;", //
-            "import java.lang.Byte;", //
-            "import java.lang.Character;", //
-            "import java.lang.Double;", //
-            "import java.lang.Float;", //
-            "import java.lang.Integer;", //
-            "import java.lang.Long;", //
-            "import java.lang.Short;", //
-            "public class Test$$IntentBuilder {", //
-            "  private Intent intent;", //
-            "  private Bundler bundler = Bundler.create();", //
-            "  public Test$$IntentBuilder(Context context) {", //
-            "    intent = new Intent(context, Test.class);", //
-            "  }", //
-            "  public Test$$IntentBuilder.AfterSettingKey_bool key_bool(Boolean key_bool) {", //
-            "    bundler.put(\"key_bool\",key_bool);", //
-            "    return new Test$$IntentBuilder.AfterSettingKey_bool();", //
-            "  }", //
-            "  public class AfterSettingKey_bool {", //
-            "    public Test$$IntentBuilder.AfterSettingKey_byte key_byte(Byte key_byte) {", //
-            "      bundler.put(\"key_byte\",key_byte);", //
-            "      return new Test$$IntentBuilder.AfterSettingKey_byte();", //
-            "    }", //
-            "  }", //
-            "  public class AfterSettingKey_byte {", //
-            "    public Test$$IntentBuilder.AfterSettingKey_char key_char(Character key_char) {", //
-            "      bundler.put(\"key_char\",key_char);", //
-            "      return new Test$$IntentBuilder.AfterSettingKey_char();", //
-            "    }", //
-            "  }", //
-            "  public class AfterSettingKey_char {", //
-            "    public Test$$IntentBuilder.AfterSettingKey_double key_double(Double key_double) {", //
-            "      bundler.put(\"key_double\",key_double);", //
-            "      return new Test$$IntentBuilder.AfterSettingKey_double();", //
-            "    }", //
-            "  }", //
-            "  public class AfterSettingKey_double {", //
-            "    public Test$$IntentBuilder.AfterSettingKey_float key_float(Float key_float) {", //
-            "      bundler.put(\"key_float\",key_float);", //
-            "      return new Test$$IntentBuilder.AfterSettingKey_float();", //
-            "    }", //
-            "  }", //
-            "  public class AfterSettingKey_float {", //
-            "    public Test$$IntentBuilder.AfterSettingKey_int key_int(Integer key_int) {", //
-            "      bundler.put(\"key_int\",key_int);", //
-            "      return new Test$$IntentBuilder.AfterSettingKey_int();", //
-            "    }", //
-            "  }", //
-            "  public class AfterSettingKey_int {", //
-            "    public Test$$IntentBuilder.AfterSettingKey_long key_long(Long key_long) {", //
-            "      bundler.put(\"key_long\",key_long);", //
-            "      return new Test$$IntentBuilder.AfterSettingKey_long();", //
-            "    }", //
-            "  }", //
-            "  public class AfterSettingKey_long {", //
-            "    public Test$$IntentBuilder.AllSet key_short(Short key_short) {", //
-            "      bundler.put(\"key_short\",key_short);", //
-            "      return new Test$$IntentBuilder.AllSet();", //
-            "    }", //
-            "  }", //
-            "  public class AllSet {", //
-            "    public Intent build() {", //
-            "      intent.putExtras(bundler.get());", //
-            "      return intent;", //
-            "    }", //
-            "  }", //
-            "}" //
+                "import android.content.Context;", //
+                "import android.content.Intent;", //
+                "import com.f2prateek.dart.henson.Bundler;", //
+                "public class Test$$IntentBuilder {", //
+                "  private Intent intent;", //
+                "  private Bundler bundler = Bundler.create();", //
+                "  public Test$$IntentBuilder(Context context) {", //
+                "    intent = new Intent(context, Test.class);", //
+                "  }", //
+                "  public Test$$IntentBuilder.AfterSettingKey_bool key_bool(boolean key_bool) {", //
+                "    bundler.put(\"key_bool\",key_bool);", //
+                "    return new Test$$IntentBuilder.AfterSettingKey_bool();", //
+                "  }", //
+                "  public class AfterSettingKey_bool {", //
+                "    public Test$$IntentBuilder.AfterSettingKey_byte key_byte(byte key_byte) {", //
+                "      bundler.put(\"key_byte\",key_byte);", //
+                "      return new Test$$IntentBuilder.AfterSettingKey_byte();", //
+                "    }", //
+                "  }", //
+                "  public class AfterSettingKey_byte {", //
+                "    public Test$$IntentBuilder.AfterSettingKey_char key_char(char key_char) {", //
+                "      bundler.put(\"key_char\",key_char);", //
+                "      return new Test$$IntentBuilder.AfterSettingKey_char();", //
+                "    }", //
+                "  }", //
+                "  public class AfterSettingKey_char {", //
+                "    public Test$$IntentBuilder.AfterSettingKey_double key_double(double key_double) {", //
+                "      bundler.put(\"key_double\",key_double);", //
+                "      return new Test$$IntentBuilder.AfterSettingKey_double();", //
+                "    }", //
+                "  }", //
+                "  public class AfterSettingKey_double {", //
+                "    public Test$$IntentBuilder.AfterSettingKey_float key_float(float key_float) {", //
+                "      bundler.put(\"key_float\",key_float);", //
+                "      return new Test$$IntentBuilder.AfterSettingKey_float();", //
+                "    }", //
+                "  }", //
+                "  public class AfterSettingKey_float {", //
+                "    public Test$$IntentBuilder.AfterSettingKey_int key_int(int key_int) {", //
+                "      bundler.put(\"key_int\",key_int);", //
+                "      return new Test$$IntentBuilder.AfterSettingKey_int();", //
+                "    }", //
+                "  }", //
+                "  public class AfterSettingKey_int {", //
+                "    public Test$$IntentBuilder.AfterSettingKey_long key_long(long key_long) {", //
+                "      bundler.put(\"key_long\",key_long);", //
+                "      return new Test$$IntentBuilder.AfterSettingKey_long();", //
+                "    }", //
+                "  }", //
+                "  public class AfterSettingKey_long {", //
+                "    public Test$$IntentBuilder.AllSet key_short(short key_short) {", //
+                "      bundler.put(\"key_short\",key_short);", //
+                "      return new Test$$IntentBuilder.AllSet();", //
+                "    }", //
+                "  }", //
+                "  public class AllSet {", //
+                "    public Intent build() {", //
+                "      intent.putExtras(bundler.get());", //
+                "      return intent;", //
+                "    }", //
+                "  }", //
+                "}" //
         ));
 
     ASSERT.about(javaSource())


### PR DESCRIPTION
Hi @f2prateek ,

here are a couple of fixes that I had to do when using Dart 2.0 RC1 into the Groupon app : 
* some types where not handled correctly (mainly array types) --> 1st commit & 3rd commit
* the classes of Android cannot be referenced in a code Generator. This issue is complex and is explained in more details in a [parceler issue](https://github.com/johncarl81/parceler/issues/11). The problem is that Maven and Gradle don't invoke the JVM that runs the annotation processor with the same classpath. With maven this classpath is the same as the classpath used to compile classes. In gradle it is a simpler classpath that doesn't include the bootclasspath of the classpath used to compile classes. The workaround, same as used in ButterKnife apparently, is to use the class names explicitely and not to refer to android classes from within a Generator. --> 2nd commit
* there was an issue when integrating Dart 2.0 with our app : we use a type that is both Serializable and Parcelable and Dart didn't know how to deal with this, being unable to know which overload of the bundler's put method to use. the workaround is to give priority to Parcelable over Serializable. The implementation has a limitation : the class must directly implement Parcelable, not via a super class. --> 4th commit. 
* in the case where there is no common package for classes using extras (which is needed by Henson to generate the Henson class into), the common package is then the default package and I had to fix this. -->5th commit. Note that this was not really mandatory as you can still use an annotation processor option (detailled in javadoc and README.MD to configure the package of the generated Henson class).
* Last commit removed useless code.


I also added tests when necessary and changed some to reflect the changes.

I am still working on the integration but I believe these will be the main issues.
