### PR TITLE
Fix proguard error

### DIFF
--- a/henson/pom.xml
+++ b/henson/pom.xml
@@ -39,13 +39,6 @@
       <scope>test</scope>
     </dependency>
 
-
-    <dependency>
-      <groupId>com.f2prateek.dart</groupId>
-      <artifactId>dart-common</artifactId>
-      <version>2.0.1-SNAPSHOT</version>
-    </dependency>
-
     <dependency>
       <groupId>com.google.android</groupId>
       <artifactId>android</artifactId>


### PR DESCRIPTION
Remove dart-common from dependencies of henson, since they're not needed
and produce warnings with Proguard, javax.lang.model package in particular