### PR TITLE
issue #128: use reflection optionally to load target classes of intents.

### DIFF
--- a/dart-processor/pom.xml
+++ b/dart-processor/pom.xml
@@ -55,7 +55,6 @@
     <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javapoet</artifactId>
-        <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraTest.java
+++ b/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
+import static com.google.common.truth.Truth.assert_;
 
 /**
  * Tests {@link com.f2prateek.dart.processor.InjectExtraProcessor}.
@@ -66,7 +66,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -151,7 +151,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -192,7 +192,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -231,7 +231,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -253,7 +253,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError();
@@ -287,7 +287,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -325,7 +325,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -345,7 +345,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -366,7 +366,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -387,7 +387,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -408,7 +408,7 @@ public class InjectExtraTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -473,7 +473,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -534,7 +534,7 @@ public class InjectExtraTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()

--- a/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraWithParcelerTest.java
+++ b/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraWithParcelerTest.java
@@ -23,7 +23,7 @@ import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
+import static com.google.common.truth.Truth.assert_;
 
 /**
  * Tests {@link com.f2prateek.dart.processor.InjectExtraProcessor}.
@@ -61,7 +61,7 @@ public class InjectExtraWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessors())
         .compilesWithoutError()
@@ -99,7 +99,7 @@ public class InjectExtraWithParcelerTest {
         "}"
             ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessors())
         .compilesWithoutError()
@@ -138,7 +138,7 @@ public class InjectExtraWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessors())
         .compilesWithoutError()
@@ -178,7 +178,7 @@ public class InjectExtraWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessors())
         .compilesWithoutError()
@@ -224,7 +224,7 @@ public class InjectExtraWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessors())
         .compilesWithoutError()
@@ -275,7 +275,7 @@ public class InjectExtraWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessors())
         .compilesWithoutError()

--- a/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraWithoutParcelerTest.java
+++ b/dart-processor/src/test/java/com/f2prateek/dart/processor/InjectExtraWithoutParcelerTest.java
@@ -23,7 +23,7 @@ import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
+import static com.google.common.truth.Truth.assert_;
 
 /**
  * Tests {@link com.f2prateek.dart.processor.InjectExtraProcessor}.
@@ -63,7 +63,7 @@ public class InjectExtraWithoutParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -85,7 +85,7 @@ public class InjectExtraWithoutParcelerTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -107,7 +107,7 @@ public class InjectExtraWithoutParcelerTest {
         "}"
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -130,7 +130,7 @@ public class InjectExtraWithoutParcelerTest {
         "}"
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .failsToCompile()
@@ -181,7 +181,7 @@ public class InjectExtraWithoutParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.dartProcessorsWithoutParceler())
         .compilesWithoutError()

--- a/henson-processor/pom.xml
+++ b/henson-processor/pom.xml
@@ -61,7 +61,6 @@
     <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javapoet</artifactId>
-        <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/HensonExtraProcessor.java
+++ b/henson-processor/src/main/java/com/f2prateek/dart/henson/processor/HensonExtraProcessor.java
@@ -62,12 +62,15 @@ import static javax.lang.model.element.Modifier.STATIC;
 public final class HensonExtraProcessor extends AbstractDartProcessor {
 
   public static final String OPTION_HENSON_PACKAGE = "dart.henson.package";
+  public static final String OPTION_HENSON_USE_REFLECTION = "dart.henson.useReflection";
 
   private String hensonPackage;
+  private boolean useReflection;
+
 
   @Override public synchronized void init(ProcessingEnvironment env) {
     super.init(env);
-    hensonPackage = env.getOptions().get(OPTION_HENSON_PACKAGE);
+    parseAnnotationProcessorOptions(env);
   }
 
   @Override public Set<String> getSupportedAnnotationTypes() {
@@ -80,6 +83,7 @@ public final class HensonExtraProcessor extends AbstractDartProcessor {
     Set<String> supportedOptions = new LinkedHashSet<>();
     supportedOptions.addAll(super.getSupportedOptions());
     supportedOptions.add(OPTION_HENSON_PACKAGE);
+    supportedOptions.add(OPTION_HENSON_USE_REFLECTION);
     return supportedOptions;
   }
 
@@ -98,7 +102,7 @@ public final class HensonExtraProcessor extends AbstractDartProcessor {
         Writer writer = null;
         try {
           IntentBuilderGenerator intentBuilderGenerator =
-              new IntentBuilderGenerator(injectionTarget);
+              new IntentBuilderGenerator(injectionTarget, useReflection);
           JavaFileObject jfo =
               filer.createSourceFile(intentBuilderGenerator.getFqcn(), typeElement);
           writer = jfo.openWriter();
@@ -181,6 +185,22 @@ public final class HensonExtraProcessor extends AbstractDartProcessor {
     }
 
     return targetClassMap;
+  }
+
+  public void setUseReflection(boolean useReflection) {
+    this.useReflection = useReflection;
+  }
+
+  private void parseAnnotationProcessorOptions(ProcessingEnvironment env) {
+    hensonPackage = env.getOptions().get(OPTION_HENSON_PACKAGE);
+    final String useReflectionOption = env.getOptions().get(OPTION_HENSON_USE_REFLECTION);
+    if (useReflectionOption != null) {
+      try {
+        useReflection = Boolean.parseBoolean(useReflectionOption);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
   }
 
   private void parseHensonNavigableAnnotatedElements(RoundEnvironment env,

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/HensonNavigatorGeneratorTest.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/HensonNavigatorGeneratorTest.java
@@ -19,12 +19,10 @@ package com.f2prateek.dart.henson.processor;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.JavaFileObjects;
-import javax.annotation.processing.Processor;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
-
+import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
 
 public class HensonNavigatorGeneratorTest {
 
@@ -57,10 +55,10 @@ public class HensonNavigatorGeneratorTest {
                 "      return new test.Test$$IntentBuilder(context);", //
                 "    }", //
                 "  }", //
-                "}" //
+            "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -99,7 +97,7 @@ public class HensonNavigatorGeneratorTest {
                 "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -142,7 +140,7 @@ public class HensonNavigatorGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError().and()
@@ -177,7 +175,7 @@ public class HensonNavigatorGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -225,7 +223,7 @@ public class HensonNavigatorGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -273,7 +271,7 @@ public class HensonNavigatorGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorTest.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorTest.java
@@ -24,7 +24,7 @@ import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
+import static com.google.common.truth.Truth.assert_;
 
 /**
  * Tests {@link com.f2prateek.dart.henson.processor.HensonExtraProcessor}.
@@ -68,7 +68,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -104,7 +104,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -152,7 +152,7 @@ public class IntentBuilderGeneratorTest {
             "}"
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -171,7 +171,7 @@ public class IntentBuilderGeneratorTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .failsToCompile()
@@ -263,7 +263,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -309,7 +309,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -353,7 +353,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -428,7 +428,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -509,7 +509,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -558,7 +558,7 @@ public class IntentBuilderGeneratorTest {
             "  }", //
             "}" //
         ));
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -634,7 +634,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -684,7 +684,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -727,7 +727,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -779,7 +779,7 @@ public class IntentBuilderGeneratorTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -797,7 +797,7 @@ public class IntentBuilderGeneratorTest {
         "}" //
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .failsToCompile()

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorWithParcelerTest.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorWithParcelerTest.java
@@ -23,7 +23,7 @@ import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
+import static com.google.common.truth.Truth.assert_;
 
 /**
  * Tests {@link com.f2prateek.dart.henson.processor.HensonExtraProcessor}.
@@ -72,7 +72,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
                 "}" //
             ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -121,7 +121,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
                   "}" //
               ));
 
-      ASSERT.about(javaSource())
+      assert_().about(javaSource())
           .that(source)
           .processedWith(ProcessorTestUtilities.hensonProcessors())
           .compilesWithoutError()
@@ -170,7 +170,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
                   "}" //
               ));
 
-      ASSERT.about(javaSource())
+      assert_().about(javaSource())
           .that(source)
           .processedWith(ProcessorTestUtilities.hensonProcessors())
           .compilesWithoutError()
@@ -220,7 +220,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
                   "}" //
               ));
 
-      ASSERT.about(javaSource())
+      assert_().about(javaSource())
           .that(source)
           .processedWith(ProcessorTestUtilities.hensonProcessors())
           .compilesWithoutError()
@@ -299,7 +299,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -353,7 +353,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()
@@ -412,7 +412,7 @@ public class IntentBuilderGeneratorWithParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessors())
         .compilesWithoutError()

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorWithReflectionTest.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorWithReflectionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013 Jake Wharton
+ * Copyright 2014 Prateek Srivastava (@f2prateek)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.f2prateek.dart.henson.processor;
+
+import com.google.common.base.Joiner;
+import com.google.testing.compile.CompileTester;
+import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static com.google.common.truth.Truth.assert_;
+
+/**
+ * Tests {@link HensonExtraProcessor}.
+ * For tests not related to Parceler.
+ */
+public class IntentBuilderGeneratorWithReflectionTest {
+
+  @Test public void injectingExtra() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", Joiner.on('\n').join( //
+        "package test;", //
+        "import android.app.Activity;", //
+        "import com.f2prateek.dart.InjectExtra;", //
+        "public class Test extends Activity {", //
+        "    @InjectExtra(\"key\") String extra;", //
+        "}" //
+    ));
+
+    JavaFileObject builderSource =
+        JavaFileObjects.forSourceString("test/Test$$IntentBuilder", Joiner.on('\n').join( //
+            "package test;", //
+            "import android.content.Context;", //
+            "import android.content.Intent;", //
+            "import com.f2prateek.dart.henson.Bundler;", //
+            "import java.lang.Class;", //
+            "import java.lang.Exception;", //
+            "import java.lang.String;", //
+            "public class Test$$IntentBuilder {", //
+            "  private Intent intent;", //
+            "  private Bundler bundler = Bundler.create();", //
+            "  public Test$$IntentBuilder(Context context) {", //
+            "    intent = new Intent(context, getClassDynamically(\"test.Test\"));", //
+            "  }", //
+            "  public Class getClassDynamically(String className) {", //
+            "    try {", //
+            "      return Class.forName(className);", //
+            "    } catch(Exception ex) {", //
+            "      throw new RuntimeException(ex);", //
+            "    }", //
+            "  }", //
+            "  public Test$$IntentBuilder.AllSet key(String extra) {", //
+            "    bundler.put(\"key\",extra);", //
+            "    return new Test$$IntentBuilder.AllSet();", //
+            "  }", //
+            "  public class AllSet {", //
+            "    public Intent build() {", //
+            "      intent.putExtras(bundler.get());", //
+            "      return intent;", //
+            "    }", //
+            "  }", //
+            "}" //
+        ));
+
+      assert_().about(javaSource())
+          .that(source)
+          .processedWith(ProcessorTestUtilities.hensonProcessorsWithReflection())
+          .compilesWithoutError()
+          .and()
+          .generatesSources(builderSource);
+  }
+}

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorWithoutParcelerTest.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/IntentBuilderGeneratorWithoutParcelerTest.java
@@ -23,7 +23,7 @@ import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
-import static org.truth0.Truth.ASSERT;
+import static com.google.common.truth.Truth.assert_;
 
 /**
  * Tests {@link com.f2prateek.dart.henson.processor.HensonExtraProcessor}.
@@ -72,7 +72,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                 "}" //
             ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()
@@ -92,7 +92,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .failsToCompile()
@@ -114,7 +114,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
         "}"
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .failsToCompile()
@@ -137,7 +137,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
         "}"
     ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .failsToCompile()
@@ -196,7 +196,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
             "}" //
         ));
 
-    ASSERT.about(javaSource())
+    assert_().about(javaSource())
         .that(source)
         .processedWith(ProcessorTestUtilities.hensonProcessorsWithoutParceler())
         .compilesWithoutError()

--- a/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/ProcessorTestUtilities.java
+++ b/henson-processor/src/test/java/com/f2prateek/dart/henson/processor/ProcessorTestUtilities.java
@@ -31,4 +31,10 @@ final class ProcessorTestUtilities {
     return Arrays.asList(hensonExtraProcessor);
   }
 
+  static Iterable<? extends Processor> hensonProcessorsWithReflection() {
+    HensonExtraProcessor hensonExtraProcessor = new HensonExtraProcessor();
+    hensonExtraProcessor.setUseReflection(true);
+    return Arrays.asList(hensonExtraProcessor);
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,9 @@
     <junit.version>4.10</junit.version>
     <robolectric.version>2.4</robolectric.version>
     <fest.android.version>1.0.7</fest.android.version>
-    <compile-test.version>0.4</compile-test.version>
+    <compile-test.version>0.9</compile-test.version>
     <parceler.version>1.0.4</parceler.version>
+    <javapoet.version>1.7.0</javapoet.version>
   </properties>
 
   <scm>
@@ -109,7 +110,11 @@
         <artifactId>parceler</artifactId>
         <version>${parceler.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>com.squareup</groupId>
+        <artifactId>javapoet</artifactId>
+        <version>${javapoet.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Solves #128 

this PR introduces a new annotation processor option for the henson processor: 
`dart.henson.useReflection=[true|false]`
which defaults to false.

TODO:
* [ ] add a wiki entry about the option