### PR TITLE
Enhanced annotation processor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ apt {
 }
 ```
 
+If you're using the newest version of Android gradle plugin, it's now possible to use a built-in annotationProcessor scope instead of apt. In this case, you can pass arguments to the annotation processors using :
+
+```groovy
+defaultConfig {
+    javaCompileOptions {
+        annotationProcessorOptions {
+            arguments = [ 'dart.henson.package' : 'your.package.name' ]
+        }
+    }
+}
+```
 
 Bonus
 -----


### PR DESCRIPTION
Add groovy snippet for new android gradle plugin annotation processor support.
Follow up of #124 