### PR TITLE
Change annotations retention in version 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ android:
     - android-sdk-license-5be876d5
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 after_success:

--- a/dart-annotations/src/main/java/com/f2prateek/dart/HensonNavigable.java
+++ b/dart-annotations/src/main/java/com/f2prateek/dart/HensonNavigable.java
@@ -4,9 +4,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
-@Retention(SOURCE)
+@Retention(CLASS)
 @Target(TYPE)
 public @interface HensonNavigable {
     Class<?> model() default Void.class;

--- a/dart-annotations/src/main/java/com/f2prateek/dart/InjectExtra.java
+++ b/dart-annotations/src/main/java/com/f2prateek/dart/InjectExtra.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Annotation for fields which indicate that it should be looked up in the activity intent's extras
@@ -35,6 +35,6 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
  *
  * @see Nullable
  */
-@Retention(SOURCE) @Target(FIELD) public @interface InjectExtra {
+@Retention(CLASS) @Target(FIELD) public @interface InjectExtra {
   String value() default "";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <module>henson-processor</module>
 
     <!-- Sample module-->
-    <module>dart-sample</module>
+    <!-- module>dart-sample</module-->
   </modules>
 
   <properties>


### PR DESCRIPTION
We need this change internally, otherwise, no dart annotations can be taken into account between modules. 