### PR TITLE
Support incremental annotation processing plus tests

### DIFF
--- a/dart-processor/src/main/java/dart/processor/ExtraBinderProcessor.java
+++ b/dart-processor/src/main/java/dart/processor/ExtraBinderProcessor.java
@@ -26,6 +26,7 @@ import dart.common.util.FileUtil;
 import dart.common.util.LoggingUtil;
 import dart.common.util.ParcelerUtil;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +51,7 @@ public final class ExtraBinderProcessor extends AbstractProcessor {
   private ExtraBindingTargetUtil extraBindingTargetUtil;
   private DartModelUtil dartModelUtil;
   private BindExtraUtil bindExtraUtil;
+  private Map<String, TypeElement> allRoundsGeneratedToTypeElement = new HashMap<>();
 
   private boolean usesParcelerOption = true;
 
@@ -112,7 +114,9 @@ public final class ExtraBinderProcessor extends AbstractProcessor {
 
       //we unfortunately can't test that nothing is generated in a TRUTH based test
       try {
-        fileUtil.writeFile(new ExtraBinderGenerator(extraBindingTarget), typeElement);
+        ExtraBinderGenerator generator = new ExtraBinderGenerator(extraBindingTarget);
+        fileUtil.writeFile(generator, typeElement);
+        allRoundsGeneratedToTypeElement.put(generator.getFqcn(), typeElement);
       } catch (IOException e) {
         loggingUtil.error(
             typeElement,
@@ -121,5 +125,10 @@ public final class ExtraBinderProcessor extends AbstractProcessor {
             e.getMessage());
       }
     }
+  }
+
+  /*visible for testing*/
+  TypeElement getOriginatingElement(String generatedQualifiedName) {
+    return allRoundsGeneratedToTypeElement.get(generatedQualifiedName);
   }
 }

--- a/dart-processor/src/main/java/dart/processor/NavigationModelBinderProcessor.java
+++ b/dart-processor/src/main/java/dart/processor/NavigationModelBinderProcessor.java
@@ -24,6 +24,7 @@ import dart.common.util.LoggingUtil;
 import dart.common.util.NavigationModelBindingTargetUtil;
 import dart.common.util.NavigationModelFieldUtil;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +46,7 @@ public final class NavigationModelBinderProcessor extends AbstractProcessor {
   private FileUtil fileUtil;
   private NavigationModelBindingTargetUtil navigationModelBindingTargetUtil;
   private NavigationModelFieldUtil navigationModelFieldUtil;
+  private Map<String, TypeElement> allRoundsGeneratedToTypeElement = new HashMap<>();
 
   @Override
   public synchronized void init(ProcessingEnvironment processingEnv) {
@@ -92,8 +94,10 @@ public final class NavigationModelBinderProcessor extends AbstractProcessor {
 
       //we unfortunately can't test that nothing is generated in a TRUTH based test
       try {
+        NavigationModelBinderGenerator generator = new NavigationModelBinderGenerator(navigationModelBindingTarget);
         fileUtil.writeFile(
-            new NavigationModelBinderGenerator(navigationModelBindingTarget), typeElement);
+            generator, typeElement);
+        allRoundsGeneratedToTypeElement.put(generator.getFqcn(), typeElement);
       } catch (IOException e) {
         loggingUtil.error(
             typeElement,
@@ -102,5 +106,10 @@ public final class NavigationModelBinderProcessor extends AbstractProcessor {
             e.getMessage());
       }
     }
+  }
+
+  /*visible for testing*/
+  TypeElement getOriginatingElement(String generatedQualifiedName) {
+    return allRoundsGeneratedToTypeElement.get(generatedQualifiedName);
   }
 }

--- a/dart-processor/src/main/java/dart/processor/NavigationModelBinderProcessor.java
+++ b/dart-processor/src/main/java/dart/processor/NavigationModelBinderProcessor.java
@@ -94,9 +94,9 @@ public final class NavigationModelBinderProcessor extends AbstractProcessor {
 
       //we unfortunately can't test that nothing is generated in a TRUTH based test
       try {
-        NavigationModelBinderGenerator generator = new NavigationModelBinderGenerator(navigationModelBindingTarget);
-        fileUtil.writeFile(
-            generator, typeElement);
+        NavigationModelBinderGenerator generator =
+            new NavigationModelBinderGenerator(navigationModelBindingTarget);
+        fileUtil.writeFile(generator, typeElement);
         allRoundsGeneratedToTypeElement.put(generator.getFqcn(), typeElement);
       } catch (IOException e) {
         loggingUtil.error(

--- a/dart-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/dart-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,2 @@
+dart.processor.ExtraBinderProcessor,isolating
+dart.processor.NavigationModelBinderProcessor,isolating

--- a/dart-processor/src/test/java/dart/processor/BindExtraTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindExtraTest.java
@@ -19,11 +19,15 @@ package dart.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.processor.ProcessorTestUtilities.*;
 import static dart.processor.ProcessorTestUtilities.extraBinderProcessorsWithoutParceler;
+import static dart.processor.ProcessorTestUtilities.getMostEnclosingElement;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -43,9 +47,10 @@ public class BindExtraTest {
                     "    @BindExtra(\"key\") String extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject binderSource =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -63,11 +68,16 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
-        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
   }
 
   @Test
@@ -90,9 +100,10 @@ public class BindExtraTest {
                     "    @BindExtra(\"key_double\") double aDouble;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject binderSource =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -144,11 +155,16 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
-        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
   }
 
   @Test
@@ -166,9 +182,10 @@ public class BindExtraTest {
                     "    @BindExtra(\"key\") String extra3;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -188,11 +205,16 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
-        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
   }
 
   @Test
@@ -210,9 +232,10 @@ public class BindExtraTest {
                     "    @BindExtra String key;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -230,11 +253,16 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
-        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
   }
 
   @Test
@@ -279,9 +307,10 @@ public class BindExtraTest {
                     "}",
                     "@Retention(CLASS) @Target(FIELD) @interface Nullable {}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -298,13 +327,18 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
   }
 
   @Test
@@ -324,7 +358,7 @@ public class BindExtraTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining("DartModel class Inner must not be private, static or abstract.")
@@ -347,7 +381,7 @@ public class BindExtraTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -371,7 +405,7 @@ public class BindExtraTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -395,7 +429,7 @@ public class BindExtraTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -424,9 +458,10 @@ public class BindExtraTest {
                     "class TestTwoNavigationModel extends TestNavigationModel {",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject expectedSource1 =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -444,9 +479,10 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    String extraBinderQualifiedName2 = "test.TestOneNavigationModel__ExtraBinder";
     JavaFileObject expectedSource2 =
         JavaFileObjects.forSourceString(
-            "test/TestOneNavigationModel__ExtraBinder",
+            extraBinderQualifiedName2,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -465,16 +501,27 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource1);
-    assertThat(compilation)
-        .generatedSourceFile("test/TestOneNavigationModel__ExtraBinder")
+
+      TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+      TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+      assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
+
+      assertThat(compilation)
+        .generatedSourceFile(extraBinderQualifiedName2)
         .hasSourceEquivalentTo(expectedSource2);
+
+    TypeElement originatingElement2 = processor.getOriginatingElement(extraBinderQualifiedName2);
+    TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
+    assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestOneNavigationModel"));
   }
 
   @Test
@@ -497,9 +544,10 @@ public class BindExtraTest {
                     "class TestTwoNavigationModel extends TestNavigationModel<Object> {",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNavigationModel__ExtraBinder";
     JavaFileObject expectedSource1 =
         JavaFileObjects.forSourceString(
-            "test/TestNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -517,9 +565,10 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    String extraBinderQualifiedName2 = "test.TestOneNavigationModel__ExtraBinder";
     JavaFileObject expectedSource2 =
         JavaFileObjects.forSourceString(
-            "test/TestOneNavigationModel__ExtraBinder",
+            extraBinderQualifiedName2,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -538,15 +587,27 @@ public class BindExtraTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource1);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestOneNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName2)
         .hasSourceEquivalentTo(expectedSource2);
+
+    TypeElement originatingElement2 = processor.getOriginatingElement(extraBinderQualifiedName2);
+    TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
+    assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestOneNavigationModel"));
+
   }
 }

--- a/dart-processor/src/test/java/dart/processor/BindExtraTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindExtraTest.java
@@ -69,8 +69,7 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource);
@@ -156,8 +155,7 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource);
@@ -206,8 +204,7 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
@@ -254,8 +251,7 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
@@ -328,10 +324,7 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
@@ -357,9 +350,7 @@ public class BindExtraTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining("DartModel class Inner must not be private, static or abstract.")
         .inFile(source)
@@ -380,9 +371,7 @@ public class BindExtraTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.TestNavigationModel.extra)")
@@ -404,9 +393,7 @@ public class BindExtraTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.TestNavigationModel.extra)")
@@ -428,9 +415,7 @@ public class BindExtraTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.TestNavigationModel.extra)")
@@ -502,26 +487,24 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
 
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource1);
 
-      TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
-      TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-      assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNavigationModel"));
 
-      assertThat(compilation)
+    assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName2)
         .hasSourceEquivalentTo(expectedSource2);
 
     TypeElement originatingElement2 = processor.getOriginatingElement(extraBinderQualifiedName2);
     TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
-    assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestOneNavigationModel"));
+    assertTrue(
+        mostEnclosingElement2.getQualifiedName().contentEquals("test.TestOneNavigationModel"));
   }
 
   @Test
@@ -588,10 +571,7 @@ public class BindExtraTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
 
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
@@ -607,7 +587,7 @@ public class BindExtraTest {
 
     TypeElement originatingElement2 = processor.getOriginatingElement(extraBinderQualifiedName2);
     TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
-    assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestOneNavigationModel"));
-
+    assertTrue(
+        mostEnclosingElement2.getQualifiedName().contentEquals("test.TestOneNavigationModel"));
   }
 }

--- a/dart-processor/src/test/java/dart/processor/BindExtraWithParcelerTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindExtraWithParcelerTest.java
@@ -19,10 +19,13 @@ package dart.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.processor.ProcessorTestUtilities.*;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -45,9 +48,10 @@ public class BindExtraWithParcelerTest {
                     "  @BindExtra(\"key\") SparseArray<String> extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestSerializableCollectionNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestSerializableCollectionNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -64,11 +68,16 @@ public class BindExtraWithParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.extraBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestSerializableCollectionNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestSerializableCollectionNavigationModel"));
   }
 
   @Test
@@ -87,9 +96,10 @@ public class BindExtraWithParcelerTest {
                     "  @BindExtra(\"key\") List<String> extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -106,12 +116,17 @@ public class BindExtraWithParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.extraBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(
-            "test/TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel__ExtraBinder")
+            extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel"));
   }
 
   @Test
@@ -131,9 +146,10 @@ public class BindExtraWithParcelerTest {
                     "  @Parcel static class Foo {}",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestParcelAnnotatedNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestParcelAnnotatedNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -150,11 +166,16 @@ public class BindExtraWithParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.extraBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestParcelAnnotatedNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelAnnotatedNavigationModel"));
   }
 
   @Test
@@ -175,9 +196,10 @@ public class BindExtraWithParcelerTest {
                     "  @Parcel static class Foo {}",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestCollectionParcelNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestCollectionParcelNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -194,11 +216,16 @@ public class BindExtraWithParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.extraBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestCollectionParcelNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestCollectionParcelNavigationModel"));
   }
 
   @Test
@@ -224,9 +251,10 @@ public class BindExtraWithParcelerTest {
                     "    @BindExtra(\"key\") Extra extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestParcelExtendsParcelableNavigationModel__ExtraBinder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test/TestParcelExtendsParcelableNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -243,11 +271,16 @@ public class BindExtraWithParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.extraBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestParcelExtendsParcelableNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelExtendsParcelableNavigationModel"));
   }
 
   @Test
@@ -278,9 +311,10 @@ public class BindExtraWithParcelerTest {
                     "    @BindExtra(\"key\") Extra extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestParcelableExtendsParcelableNavigationModel__ExtraBinder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test/TestParcelableExtendsParcelableNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -297,10 +331,15 @@ public class BindExtraWithParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.extraBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestParcelableExtendsParcelableNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelableExtendsParcelableNavigationModel"));
   }
 }

--- a/dart-processor/src/test/java/dart/processor/BindExtraWithParcelerTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindExtraWithParcelerTest.java
@@ -69,15 +69,17 @@ public class BindExtraWithParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestSerializableCollectionNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestSerializableCollectionNavigationModel"));
   }
 
   @Test
@@ -96,7 +98,8 @@ public class BindExtraWithParcelerTest {
                     "  @BindExtra(\"key\") List<String> extra;",
                     "}"));
 
-    String extraBinderQualifiedName = "test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel__ExtraBinder";
+    String extraBinderQualifiedName =
+        "test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
             extraBinderQualifiedName,
@@ -117,16 +120,18 @@ public class BindExtraWithParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile(
-            extraBinderQualifiedName)
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals(
+                "test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel"));
   }
 
   @Test
@@ -167,15 +172,17 @@ public class BindExtraWithParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelAnnotatedNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestParcelAnnotatedNavigationModel"));
   }
 
   @Test
@@ -217,15 +224,17 @@ public class BindExtraWithParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestCollectionParcelNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestCollectionParcelNavigationModel"));
   }
 
   @Test
@@ -251,7 +260,8 @@ public class BindExtraWithParcelerTest {
                     "    @BindExtra(\"key\") Extra extra;",
                     "}"));
 
-    String extraBinderQualifiedName = "test.TestParcelExtendsParcelableNavigationModel__ExtraBinder";
+    String extraBinderQualifiedName =
+        "test.TestParcelExtendsParcelableNavigationModel__ExtraBinder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
             extraBinderQualifiedName,
@@ -272,15 +282,17 @@ public class BindExtraWithParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelExtendsParcelableNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestParcelExtendsParcelableNavigationModel"));
   }
 
   @Test
@@ -311,7 +323,8 @@ public class BindExtraWithParcelerTest {
                     "    @BindExtra(\"key\") Extra extra;",
                     "}"));
 
-    String extraBinderQualifiedName = "test.TestParcelableExtendsParcelableNavigationModel__ExtraBinder";
+    String extraBinderQualifiedName =
+        "test.TestParcelableExtendsParcelableNavigationModel__ExtraBinder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
             extraBinderQualifiedName,
@@ -332,14 +345,16 @@ public class BindExtraWithParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelableExtendsParcelableNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestParcelableExtendsParcelableNavigationModel"));
   }
 }

--- a/dart-processor/src/test/java/dart/processor/BindExtraWithoutParcelerTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindExtraWithoutParcelerTest.java
@@ -19,10 +19,13 @@ package dart.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.processor.ProcessorTestUtilities.*;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -47,9 +50,10 @@ public class BindExtraWithoutParcelerTest {
                     "  @BindExtra(\"key\") ArrayList<String> extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestSerializableCollectionNavigationModel__ExtraBinder";
     JavaFileObject expectedSource =
         JavaFileObjects.forSourceString(
-            "test/TestSerializableCollectionNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -68,13 +72,18 @@ public class BindExtraWithoutParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestSerializableCollectionNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestSerializableCollectionNavigationModel"));
   }
 
   @Test
@@ -96,7 +105,7 @@ public class BindExtraWithoutParcelerTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -122,7 +131,7 @@ public class BindExtraWithoutParcelerTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -149,7 +158,7 @@ public class BindExtraWithoutParcelerTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(extraBinderProcessorsWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -184,9 +193,10 @@ public class BindExtraWithoutParcelerTest {
                     "    @BindExtra(\"key\") Extra extra;",
                     "}"));
 
+    String extraBinderQualifiedName = "test.TestParcelableExtendsParcelableNavigationModel__ExtraBinder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test/TestParcelableExtendsParcelableNavigationModel__ExtraBinder",
+            extraBinderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test;",
@@ -203,12 +213,17 @@ public class BindExtraWithoutParcelerTest {
                     "  }",
                     "}"));
 
+    ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.extraBinderProcessorsWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestParcelableExtendsParcelableNavigationModel__ExtraBinder")
+        .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelableExtendsParcelableNavigationModel"));
   }
 }

--- a/dart-processor/src/test/java/dart/processor/BindExtraWithoutParcelerTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindExtraWithoutParcelerTest.java
@@ -73,17 +73,17 @@ public class BindExtraWithoutParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(expectedSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestSerializableCollectionNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestSerializableCollectionNavigationModel"));
   }
 
   @Test
@@ -104,9 +104,7 @@ public class BindExtraWithoutParcelerTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.TestNonSerializableNonParcelableCollection_withoutParcelerNavigationModel.extra).");
@@ -130,9 +128,7 @@ public class BindExtraWithoutParcelerTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.TestParcelAnnotatedNavigationModel.extra).");
@@ -157,9 +153,7 @@ public class BindExtraWithoutParcelerTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(extraBinderProcessorsWithoutParceler())
-            .compile(source);
+        javac().withProcessors(extraBinderProcessorsWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.TestCollectionParcelNavigationModel.extra).");
@@ -193,7 +187,8 @@ public class BindExtraWithoutParcelerTest {
                     "    @BindExtra(\"key\") Extra extra;",
                     "}"));
 
-    String extraBinderQualifiedName = "test.TestParcelableExtendsParcelableNavigationModel__ExtraBinder";
+    String extraBinderQualifiedName =
+        "test.TestParcelableExtendsParcelableNavigationModel__ExtraBinder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
             extraBinderQualifiedName,
@@ -214,16 +209,16 @@ public class BindExtraWithoutParcelerTest {
                     "}"));
 
     ExtraBinderProcessor processor = extraBinderProcessorsWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(extraBinderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(extraBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestParcelableExtendsParcelableNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.TestParcelableExtendsParcelableNavigationModel"));
   }
 }

--- a/dart-processor/src/test/java/dart/processor/BindNavigationModelTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindNavigationModelTest.java
@@ -73,13 +73,13 @@ public class BindNavigationModelTest {
                     "}"));
 
     NavigationModelBinderProcessor processor = navigationModelBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(navigationModelBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource);
 
-    TypeElement originatingElement = processor.getOriginatingElement(navigationModelBinderQualifiedName);
+    TypeElement originatingElement =
+        processor.getOriginatingElement(navigationModelBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
     assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestActivity"));
   }
@@ -240,23 +240,23 @@ public class BindNavigationModelTest {
                     "}"));
 
     NavigationModelBinderProcessor processor = navigationModelBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
 
     assertThat(compilation)
         .generatedSourceFile(navigationModelBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource1);
 
-    TypeElement originatingElement = processor.getOriginatingElement(navigationModelBinderQualifiedName);
+    TypeElement originatingElement =
+        processor.getOriginatingElement(navigationModelBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
     assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestActivity"));
-
 
     assertThat(compilation)
         .generatedSourceFile(navigationModelBinderQualifiedName2)
         .hasSourceEquivalentTo(binderSource2);
 
-    TypeElement originatingElement2 = processor.getOriginatingElement(navigationModelBinderQualifiedName2);
+    TypeElement originatingElement2 =
+        processor.getOriginatingElement(navigationModelBinderQualifiedName2);
     TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
     assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestSuperActivity"));
   }
@@ -340,7 +340,8 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
-    String navigationModelBinderQualifiedName3 = "test.TestGrandParentActivity__NavigationModelBinder";
+    String navigationModelBinderQualifiedName3 =
+        "test.TestGrandParentActivity__NavigationModelBinder";
     JavaFileObject binderSource3 =
         JavaFileObjects.forSourceString(
             navigationModelBinderQualifiedName3,
@@ -359,14 +360,14 @@ public class BindNavigationModelTest {
                     "}"));
 
     NavigationModelBinderProcessor processor = navigationModelBinderProcessors();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
 
     assertThat(compilation)
         .generatedSourceFile(navigationModelBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource1);
 
-    TypeElement originatingElement = processor.getOriginatingElement(navigationModelBinderQualifiedName);
+    TypeElement originatingElement =
+        processor.getOriginatingElement(navigationModelBinderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
     assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestActivity"));
 
@@ -374,7 +375,8 @@ public class BindNavigationModelTest {
         .generatedSourceFile(navigationModelBinderQualifiedName2)
         .hasSourceEquivalentTo(binderSource2);
 
-    TypeElement originatingElement2 = processor.getOriginatingElement(navigationModelBinderQualifiedName2);
+    TypeElement originatingElement2 =
+        processor.getOriginatingElement(navigationModelBinderQualifiedName2);
     TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
     assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestParentActivity"));
 
@@ -382,9 +384,11 @@ public class BindNavigationModelTest {
         .generatedSourceFile(navigationModelBinderQualifiedName3)
         .hasSourceEquivalentTo(binderSource3);
 
-    TypeElement originatingElement3 = processor.getOriginatingElement(navigationModelBinderQualifiedName3);
+    TypeElement originatingElement3 =
+        processor.getOriginatingElement(navigationModelBinderQualifiedName3);
     TypeElement mostEnclosingElement3 = getMostEnclosingElement(originatingElement3);
-    assertTrue(mostEnclosingElement3.getQualifiedName().contentEquals("test.TestGrandParentActivity"));
+    assertTrue(
+        mostEnclosingElement3.getQualifiedName().contentEquals("test.TestGrandParentActivity"));
   }
 
   @Test

--- a/dart-processor/src/test/java/dart/processor/BindNavigationModelTest.java
+++ b/dart-processor/src/test/java/dart/processor/BindNavigationModelTest.java
@@ -19,11 +19,14 @@ package dart.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.processor.ProcessorTestUtilities.getMostEnclosingElement;
 import static dart.processor.ProcessorTestUtilities.navigationModelBinderProcessors;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -51,9 +54,10 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    String navigationModelBinderQualifiedName = "test.TestActivity__NavigationModelBinder";
     JavaFileObject binderSource =
         JavaFileObjects.forSourceString(
-            "test/TestActivity__NavigationModelBinder",
+            navigationModelBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -68,11 +72,16 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    NavigationModelBinderProcessor processor = navigationModelBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(navigationModelBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test/TestActivity__NavigationModelBinder")
+        .generatedSourceFile(navigationModelBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(navigationModelBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestActivity"));
   }
 
   @Test
@@ -192,9 +201,10 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    String navigationModelBinderQualifiedName = "test.TestActivity__NavigationModelBinder";
     JavaFileObject binderSource1 =
         JavaFileObjects.forSourceString(
-            "test/TestActivity__NavigationModelBinder",
+            navigationModelBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -211,9 +221,10 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    String navigationModelBinderQualifiedName2 = "test.TestSuperActivity__NavigationModelBinder";
     JavaFileObject binderSource2 =
         JavaFileObjects.forSourceString(
-            "test/TestActivity__NavigationModelBinder",
+            navigationModelBinderQualifiedName2,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -228,14 +239,26 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    NavigationModelBinderProcessor processor = navigationModelBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(navigationModelBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestActivity__NavigationModelBinder")
+        .generatedSourceFile(navigationModelBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource1);
+
+    TypeElement originatingElement = processor.getOriginatingElement(navigationModelBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestActivity"));
+
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestSuperActivity__NavigationModelBinder")
+        .generatedSourceFile(navigationModelBinderQualifiedName2)
         .hasSourceEquivalentTo(binderSource2);
+
+    TypeElement originatingElement2 = processor.getOriginatingElement(navigationModelBinderQualifiedName2);
+    TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
+    assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestSuperActivity"));
   }
 
   @Test
@@ -277,9 +300,10 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    String navigationModelBinderQualifiedName = "test.TestActivity__NavigationModelBinder";
     JavaFileObject binderSource1 =
         JavaFileObjects.forSourceString(
-            "test/TestActivity__NavigationModelBinder",
+            navigationModelBinderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -296,9 +320,10 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    String navigationModelBinderQualifiedName2 = "test.TestParentActivity__NavigationModelBinder";
     JavaFileObject binderSource2 =
         JavaFileObjects.forSourceString(
-            "test/TestParentActivity__NavigationModelBinder",
+            navigationModelBinderQualifiedName2,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -315,9 +340,10 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    String navigationModelBinderQualifiedName3 = "test.TestGrandParentActivity__NavigationModelBinder";
     JavaFileObject binderSource3 =
         JavaFileObjects.forSourceString(
-            "test/TestGrandParentActivity__NavigationModelBinder",
+            navigationModelBinderQualifiedName3,
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -332,17 +358,33 @@ public class BindNavigationModelTest {
                     "  }",
                     "}"));
 
+    NavigationModelBinderProcessor processor = navigationModelBinderProcessors();
     Compilation compilation =
-        javac().withProcessors(navigationModelBinderProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestActivity__NavigationModelBinder")
+        .generatedSourceFile(navigationModelBinderQualifiedName)
         .hasSourceEquivalentTo(binderSource1);
+
+    TypeElement originatingElement = processor.getOriginatingElement(navigationModelBinderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.TestActivity"));
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestParentActivity__NavigationModelBinder")
+        .generatedSourceFile(navigationModelBinderQualifiedName2)
         .hasSourceEquivalentTo(binderSource2);
+
+    TypeElement originatingElement2 = processor.getOriginatingElement(navigationModelBinderQualifiedName2);
+    TypeElement mostEnclosingElement2 = getMostEnclosingElement(originatingElement2);
+    assertTrue(mostEnclosingElement2.getQualifiedName().contentEquals("test.TestParentActivity"));
+
     assertThat(compilation)
-        .generatedSourceFile("test/TestGrandParentActivity__NavigationModelBinder")
+        .generatedSourceFile(navigationModelBinderQualifiedName3)
         .hasSourceEquivalentTo(binderSource3);
+
+    TypeElement originatingElement3 = processor.getOriginatingElement(navigationModelBinderQualifiedName3);
+    TypeElement mostEnclosingElement3 = getMostEnclosingElement(originatingElement3);
+    assertTrue(mostEnclosingElement3.getQualifiedName().contentEquals("test.TestGrandParentActivity"));
   }
 
   @Test
@@ -379,7 +421,7 @@ public class BindNavigationModelTest {
 
     JavaFileObject binderSource1 =
         JavaFileObjects.forSourceString(
-            "test/TestActivity__NavigationModelBinder",
+            "test.TestActivity__NavigationModelBinder",
             Joiner.on('\n')
                 .join(
                     "package test;",
@@ -398,7 +440,7 @@ public class BindNavigationModelTest {
 
     JavaFileObject binderSource2 =
         JavaFileObjects.forSourceString(
-            "test/TestActivity__NavigationModelBinder",
+            "test.TestActivity__NavigationModelBinder",
             Joiner.on('\n')
                 .join(
                     "package test;",

--- a/dart-processor/src/test/java/dart/processor/ProcessorTestUtilities.java
+++ b/dart-processor/src/test/java/dart/processor/ProcessorTestUtilities.java
@@ -36,14 +36,15 @@ final class ProcessorTestUtilities {
   }
 
   static TypeElement getMostEnclosingElement(Element element) {
-    if(element == null) {
+    if (element == null) {
       return null;
     }
 
-    while (element.getEnclosingElement() != null && element.getEnclosingElement().getKind().isClass() || element.getEnclosingElement().getKind().isInterface()) {
+    while (element.getEnclosingElement() != null
+            && element.getEnclosingElement().getKind().isClass()
+        || element.getEnclosingElement().getKind().isInterface()) {
       element = element.getEnclosingElement();
     }
     return (TypeElement) element;
   }
-
 }

--- a/dart-processor/src/test/java/dart/processor/ProcessorTestUtilities.java
+++ b/dart-processor/src/test/java/dart/processor/ProcessorTestUtilities.java
@@ -17,21 +17,33 @@
 
 package dart.processor;
 
-import java.util.Arrays;
-import javax.annotation.processing.Processor;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 
 final class ProcessorTestUtilities {
-  static Iterable<? extends Processor> extraBinderProcessors() {
-    return Arrays.asList(new ExtraBinderProcessor());
+  static ExtraBinderProcessor extraBinderProcessors() {
+    return new ExtraBinderProcessor();
   }
 
-  static Iterable<? extends Processor> extraBinderProcessorsWithoutParceler() {
+  static ExtraBinderProcessor extraBinderProcessorsWithoutParceler() {
     ExtraBinderProcessor bindExtraProcessor = new ExtraBinderProcessor();
     bindExtraProcessor.enableParceler(false);
-    return Arrays.asList(bindExtraProcessor);
+    return bindExtraProcessor;
   }
 
-  static Iterable<? extends Processor> navigationModelBinderProcessors() {
-    return Arrays.asList(new NavigationModelBinderProcessor());
+  static NavigationModelBinderProcessor navigationModelBinderProcessors() {
+    return new NavigationModelBinderProcessor();
   }
+
+  static TypeElement getMostEnclosingElement(Element element) {
+    if(element == null) {
+      return null;
+    }
+
+    while (element.getEnclosingElement() != null && element.getEnclosingElement().getKind().isClass() || element.getEnclosingElement().getKind().isInterface()) {
+      element = element.getEnclosingElement();
+    }
+    return (TypeElement) element;
+  }
+
 }

--- a/henson-plugin/src/main/resources/build.properties
+++ b/henson-plugin/src/main/resources/build.properties
@@ -1,2 +1,2 @@
-#Wed Sep 26 08:19:50 PDT 2018
+#Tue Jan 08 06:35:17 PST 2019
 dart.version=3.0.4-SNAPSHOT

--- a/henson-processor/src/main/java/dart/henson/processor/IntentBuilderProcessor.java
+++ b/henson-processor/src/main/java/dart/henson/processor/IntentBuilderProcessor.java
@@ -57,7 +57,6 @@ public class IntentBuilderProcessor extends AbstractProcessor {
 
   private String hensonPackage;
   private boolean usesParceler = true;
-  private Map<TypeElement, ExtraBindingTarget> targetClassMap;
   private Map<String, TypeElement> allRoundsGeneratedToTypeElement = new HashMap<>();
 
   @Override
@@ -87,7 +86,7 @@ public class IntentBuilderProcessor extends AbstractProcessor {
     dartModelUtil.setRoundEnvironment(roundEnv);
     bindExtraUtil.setRoundEnvironment(roundEnv);
 
-    targetClassMap = findAndParseTargets();
+    final Map<TypeElement, ExtraBindingTarget> targetClassMap = findAndParseTargets();
     generateIntentBuilders(targetClassMap);
 
     //return false here to let dart process the annotations too

--- a/henson-processor/src/main/java/dart/henson/processor/IntentBuilderProcessor.java
+++ b/henson-processor/src/main/java/dart/henson/processor/IntentBuilderProcessor.java
@@ -26,6 +26,7 @@ import dart.common.util.FileUtil;
 import dart.common.util.LoggingUtil;
 import dart.common.util.ParcelerUtil;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -56,6 +57,8 @@ public class IntentBuilderProcessor extends AbstractProcessor {
 
   private String hensonPackage;
   private boolean usesParceler = true;
+  private Map<TypeElement, ExtraBindingTarget> targetClassMap;
+  private Map<String, TypeElement> allRoundsGeneratedToTypeElement = new HashMap<>();
 
   @Override
   public synchronized void init(ProcessingEnvironment processingEnv) {
@@ -84,7 +87,7 @@ public class IntentBuilderProcessor extends AbstractProcessor {
     dartModelUtil.setRoundEnvironment(roundEnv);
     bindExtraUtil.setRoundEnvironment(roundEnv);
 
-    Map<TypeElement, ExtraBindingTarget> targetClassMap = findAndParseTargets();
+    targetClassMap = findAndParseTargets();
     generateIntentBuilders(targetClassMap);
 
     //return false here to let dart process the annotations too
@@ -128,7 +131,9 @@ public class IntentBuilderProcessor extends AbstractProcessor {
     //we unfortunately can't test that nothing is generated in a TRUTH based test
     final ExtraBindingTarget extraBindingTarget = targetClassMap.get(typeElement);
     try {
-      fileUtil.writeFile(new IntentBuilderGenerator(extraBindingTarget), typeElement);
+      IntentBuilderGenerator generator = new IntentBuilderGenerator(extraBindingTarget);
+      fileUtil.writeFile(generator, typeElement);
+      allRoundsGeneratedToTypeElement.put(generator.getFqcn(), typeElement);
     } catch (IOException e) {
       loggingUtil.error(
           typeElement,
@@ -140,5 +145,10 @@ public class IntentBuilderProcessor extends AbstractProcessor {
     for (TypeElement child : extraBindingTarget.childClasses) {
       generateIntentBuildersForTree(targetClassMap, child);
     }
+  }
+
+  /*visible for testing*/
+  TypeElement getOriginatingElement(String generatedQualifiedName) {
+    return allRoundsGeneratedToTypeElement.get(generatedQualifiedName);
   }
 }

--- a/henson-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/henson-processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+dart.henson.processor.IntentBuilderProcessor,isolating

--- a/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorTest.java
+++ b/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorTest.java
@@ -27,7 +27,6 @@ import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
 import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class IntentBuilderGeneratorTest {
@@ -99,15 +98,17 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -164,15 +165,17 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -240,15 +243,17 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -311,15 +316,17 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -393,15 +400,17 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -474,15 +483,17 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -550,15 +561,17 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -576,8 +589,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -598,8 +610,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -618,8 +629,7 @@ public class IntentBuilderGeneratorTest {
                     "public abstract class TestNavigationModel {",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -638,8 +648,7 @@ public class IntentBuilderGeneratorTest {
                     "public interface TestNavigationModel {",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -660,8 +669,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining("DartModel class TestNavigationModel must be a top level class.");
   }
@@ -680,8 +688,7 @@ public class IntentBuilderGeneratorTest {
                     "  private TestNavigationModel() {}",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel default constructor must not be private.");
@@ -702,8 +709,7 @@ public class IntentBuilderGeneratorTest {
                     "  public TestNavigationModel(String parameter) {}",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining("DartModel class TestNavigationModel must have a default constructor.");
   }
@@ -721,8 +727,7 @@ public class IntentBuilderGeneratorTest {
                     "class TestModel {",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestModel does not follow the naming convention: my.package.TargetComponentNavigationModel.");
@@ -741,8 +746,7 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra private String extra;",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.navigation.TestNavigationModel.extra)");
@@ -761,8 +765,7 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra static String extra;",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.navigation.TestNavigationModel.extra)");
@@ -781,8 +784,7 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra Object extra;",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.navigation.TestNavigationModel.extra).");
@@ -801,8 +803,7 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra(\"my.key\") String extra;",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra key has to be a valid java variable identifier (test.navigation.TestNavigationModel#extra).");
@@ -919,8 +920,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
@@ -998,8 +998,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
@@ -1071,9 +1070,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(hensonProcessorWithoutParceler())
-            .compile(source);
+        javac().withProcessors(hensonProcessorWithoutParceler()).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
@@ -1204,8 +1201,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1328,8 +1324,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1452,8 +1447,7 @@ public class IntentBuilderGeneratorTest {
                     "  } ",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1565,8 +1559,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1590,8 +1583,7 @@ public class IntentBuilderGeneratorTest {
                     "class SuperClass {",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel test.navigation.TestNavigationModel parent does not have an IntentBuilder. Is test.navigation.SuperClass annotated with @DartModel or contains @BindExtra fields?");
@@ -1752,8 +1744,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1931,8 +1922,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -2014,8 +2004,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -2091,8 +2080,7 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
-    Compilation compilation =
-        javac().withProcessors(hensonProcessor()).compile(source);
+    Compilation compilation = javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);

--- a/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorTest.java
+++ b/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorTest.java
@@ -19,11 +19,15 @@ package dart.henson.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.henson.processor.ProcessorTestUtilities.*;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class IntentBuilderGeneratorTest {
@@ -44,9 +48,10 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra String extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -93,11 +98,16 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -114,9 +124,10 @@ public class IntentBuilderGeneratorTest {
                     "public class TestNavigationModel {",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -152,11 +163,16 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -173,9 +189,10 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra String extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -222,11 +239,16 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -244,9 +266,10 @@ public class IntentBuilderGeneratorTest {
                     "    @Nullable @BindExtra String extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -287,11 +310,16 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -310,9 +338,10 @@ public class IntentBuilderGeneratorTest {
                     "    @Nullable @BindExtra String extra2;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -363,11 +392,16 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -385,9 +419,10 @@ public class IntentBuilderGeneratorTest {
                     "    @Nullable @BindExtra(\"key2\") String extra2;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -438,11 +473,16 @@ public class IntentBuilderGeneratorTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -460,9 +500,10 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra(\"key\") String extra3;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -508,12 +549,16 @@ public class IntentBuilderGeneratorTest {
                     "    }",
                     "  }",
                     "}"));
-
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -532,7 +577,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -554,7 +599,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -574,7 +619,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -594,7 +639,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel must not be private, static or abstract.");
@@ -616,7 +661,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining("DartModel class TestNavigationModel must be a top level class.");
   }
@@ -636,7 +681,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestNavigationModel default constructor must not be private.");
@@ -658,7 +703,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining("DartModel class TestNavigationModel must have a default constructor.");
   }
@@ -677,7 +722,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel class TestModel does not follow the naming convention: my.package.TargetComponentNavigationModel.");
@@ -697,7 +742,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.navigation.TestNavigationModel.extra)");
@@ -717,7 +762,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra field must not be private or static. (test.navigation.TestNavigationModel.extra)");
@@ -737,7 +782,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.navigation.TestNavigationModel.extra).");
@@ -757,7 +802,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "@BindExtra key has to be a valid java variable identifier (test.navigation.TestNavigationModel#extra).");
@@ -783,9 +828,10 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra double aDouble;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -874,9 +920,9 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
   }
 
@@ -903,9 +949,10 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra Extra extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -952,9 +999,9 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
   }
 
@@ -972,9 +1019,10 @@ public class IntentBuilderGeneratorTest {
                     "    @BindExtra ArrayList<String> list;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join(
                     "package test.navigation;",
@@ -1024,10 +1072,10 @@ public class IntentBuilderGeneratorTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(hensonProcessorWithoutParceler())
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
   }
 
@@ -1157,7 +1205,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1281,7 +1329,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1405,7 +1453,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1518,7 +1566,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1543,7 +1591,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "DartModel test.navigation.TestNavigationModel parent does not have an IntentBuilder. Is test.navigation.SuperClass annotated with @DartModel or contains @BindExtra fields?");
@@ -1705,7 +1753,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1884,7 +1932,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -1967,7 +2015,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);
@@ -2044,7 +2092,7 @@ public class IntentBuilderGeneratorTest {
                     "}"));
 
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(hensonProcessor()).compile(source);
     assertThat(compilation)
         .generatedSourceFile("test.navigation.Test1__IntentBuilder")
         .hasSourceEquivalentTo(builderSource1);

--- a/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithParcelerTest.java
+++ b/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithParcelerTest.java
@@ -19,10 +19,15 @@ package dart.henson.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.henson.processor.ProcessorTestUtilities.getMostEnclosingElement;
+import static dart.henson.processor.ProcessorTestUtilities.hensonProcessor;
+import static dart.henson.processor.ProcessorTestUtilities.hensonProcessorWithoutParceler;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -43,9 +48,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    @BindExtra ArrayList<String> extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -93,11 +99,16 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -114,9 +125,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    @BindExtra List<String> extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -164,11 +176,16 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -187,9 +204,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    @Parcel static class ClassWithRequiredAndOptionalExtrasNavigationModel {}",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -235,11 +253,16 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -259,9 +282,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    @Parcel static class ClassWithRequiredAndOptionalExtrasNavigationModel {}",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -307,11 +331,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    }",
                     "  }",
                     "}"));
+
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -346,9 +376,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     //
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -409,11 +440,16 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -446,9 +482,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    }",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -494,11 +531,16 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -525,9 +567,10 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "    @Parcel class ClassWithRequiredAndOptionalExtrasNavigationModel extends FooParent {} ",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -573,10 +616,15 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessor();
     Compilation compilation =
-        javac().withProcessors(ProcessorTestUtilities.hensonProcessors()).compile(source);
+        javac().withProcessors(processor).compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 }

--- a/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithParcelerTest.java
+++ b/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithParcelerTest.java
@@ -21,7 +21,6 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static dart.henson.processor.ProcessorTestUtilities.getMostEnclosingElement;
 import static dart.henson.processor.ProcessorTestUtilities.hensonProcessor;
-import static dart.henson.processor.ProcessorTestUtilities.hensonProcessorWithoutParceler;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
@@ -100,15 +99,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -177,15 +178,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -254,15 +257,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -333,15 +338,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -441,15 +448,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -532,15 +541,17 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -617,14 +628,16 @@ public class IntentBuilderGeneratorWithParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessor();
-    Compilation compilation =
-        javac().withProcessors(processor).compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 }

--- a/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithoutParcelerTest.java
+++ b/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithoutParcelerTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
-import javax.annotation.processing.Processor;
 import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
@@ -100,17 +99,17 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessorWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -128,9 +127,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(hensonProcessorWithoutParceler())
-            .compile(source);
+        javac().withProcessors(hensonProcessorWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.navigation.TestNavigationModel.extra).");
@@ -153,9 +150,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(hensonProcessorWithoutParceler())
-            .compile(source);
+        javac().withProcessors(hensonProcessorWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.navigation.TestNavigationModel.extra).");
@@ -178,9 +173,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "}"));
 
     Compilation compilation =
-        javac()
-            .withProcessors(hensonProcessorWithoutParceler())
-            .compile(source);
+        javac().withProcessors(hensonProcessorWithoutParceler()).compile(source);
     assertThat(compilation)
         .hadErrorContaining(
             "The fields of class annotated with @DartModel must be primitive, Serializable or Parcelable (test.navigation.TestNavigationModel.extra).");
@@ -258,17 +251,17 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessorWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -352,16 +345,16 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "}"));
 
     IntentBuilderProcessor processor = hensonProcessorWithoutParceler();
-    Compilation compilation =
-        javac()
-            .withProcessors(processor)
-            .compile(source);
+    Compilation compilation = javac().withProcessors(processor).compile(source);
     assertThat(compilation)
         .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
 
     TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
     TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
-    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
+    assertTrue(
+        mostEnclosingElement
+            .getQualifiedName()
+            .contentEquals("test.navigation.TestNavigationModel"));
   }
 }

--- a/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithoutParcelerTest.java
+++ b/henson-processor/src/test/java/dart/henson/processor/IntentBuilderGeneratorWithoutParcelerTest.java
@@ -19,10 +19,15 @@ package dart.henson.processor;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static dart.henson.processor.ProcessorTestUtilities.getMostEnclosingElement;
+import static dart.henson.processor.ProcessorTestUtilities.hensonProcessorWithoutParceler;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
+import javax.annotation.processing.Processor;
+import javax.lang.model.element.TypeElement;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -43,9 +48,10 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "    @BindExtra ArrayList<String> extra;",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -93,13 +99,18 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessorWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -118,7 +129,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(hensonProcessorWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -143,7 +154,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(hensonProcessorWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -168,7 +179,7 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
 
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(hensonProcessorWithoutParceler())
             .compile(source);
     assertThat(compilation)
         .hadErrorContaining(
@@ -197,9 +208,10 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "    }",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -245,13 +257,18 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessorWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 
   @Test
@@ -284,9 +301,10 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "    }",
                     "}"));
 
+    String intentBuilderQualifiedName = "test.navigation.Test__IntentBuilder";
     JavaFileObject builderSource =
         JavaFileObjects.forSourceString(
-            "test.navigation.Test__IntentBuilder",
+            intentBuilderQualifiedName,
             Joiner.on('\n')
                 .join( //
                     "package test.navigation;",
@@ -333,12 +351,17 @@ public class IntentBuilderGeneratorWithoutParcelerTest {
                     "  }",
                     "}"));
 
+    IntentBuilderProcessor processor = hensonProcessorWithoutParceler();
     Compilation compilation =
         javac()
-            .withProcessors(ProcessorTestUtilities.hensonProcessorWithoutParceler())
+            .withProcessors(processor)
             .compile(source);
     assertThat(compilation)
-        .generatedSourceFile("test.navigation.Test__IntentBuilder")
+        .generatedSourceFile(intentBuilderQualifiedName)
         .hasSourceEquivalentTo(builderSource);
+
+    TypeElement originatingElement = processor.getOriginatingElement(intentBuilderQualifiedName);
+    TypeElement mostEnclosingElement = getMostEnclosingElement(originatingElement);
+    assertTrue(mostEnclosingElement.getQualifiedName().contentEquals("test.navigation.TestNavigationModel"));
   }
 }

--- a/henson-processor/src/test/java/dart/henson/processor/ProcessorTestUtilities.java
+++ b/henson-processor/src/test/java/dart/henson/processor/ProcessorTestUtilities.java
@@ -32,12 +32,14 @@ public class ProcessorTestUtilities {
   }
 
   static TypeElement getMostEnclosingElement(Element element) {
-    if(element == null) {
+    if (element == null) {
       return null;
     }
 
-    while (element.getEnclosingElement() != null && element.getEnclosingElement().getKind().isClass() || element.getEnclosingElement().getKind().isInterface()) {
-        element = element.getEnclosingElement();
+    while (element.getEnclosingElement() != null
+            && element.getEnclosingElement().getKind().isClass()
+        || element.getEnclosingElement().getKind().isInterface()) {
+      element = element.getEnclosingElement();
     }
     return (TypeElement) element;
   }

--- a/henson-processor/src/test/java/dart/henson/processor/ProcessorTestUtilities.java
+++ b/henson-processor/src/test/java/dart/henson/processor/ProcessorTestUtilities.java
@@ -17,17 +17,28 @@
 
 package dart.henson.processor;
 
-import java.util.Arrays;
-import javax.annotation.processing.Processor;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 
 public class ProcessorTestUtilities {
-  static Iterable<? extends Processor> hensonProcessors() {
-    return Arrays.asList(new IntentBuilderProcessor());
+  static IntentBuilderProcessor hensonProcessor() {
+    return new IntentBuilderProcessor();
   }
 
-  static Iterable<? extends Processor> hensonProcessorWithoutParceler() {
+  static IntentBuilderProcessor hensonProcessorWithoutParceler() {
     IntentBuilderProcessor intentBuilderProcessor = new IntentBuilderProcessor();
     intentBuilderProcessor.enableParceler(false);
-    return Arrays.asList(intentBuilderProcessor);
+    return intentBuilderProcessor;
+  }
+
+  static TypeElement getMostEnclosingElement(Element element) {
+    if(element == null) {
+      return null;
+    }
+
+    while (element.getEnclosingElement() != null && element.getEnclosingElement().getKind().isClass() || element.getEnclosingElement().getKind().isInterface()) {
+        element = element.getEnclosingElement();
+    }
+    return (TypeElement) element;
   }
 }


### PR DESCRIPTION
This PR adds support for incremental annotation processing as defined by gradle'incap project:
https://docs.gradle.org/4.7/userguide/java_plugin.html#sec:incremental_annotation_processing

All 3 annotation processors have been enhanced to become incremental and they all are isolating.

The PR has 2 parts: 
* add support for incremental annotation processing: add the meta-inf file and make sure the originating element of all generated files is passed to the filer properly.
* add tests: I didn't want to add integration tests (they would ensure that incremental compilation truly works) as they would require quite some news mecanics (gradle testing + spock). So I simply added unit tests to make sure that originating elements are passed properly to gradle.

If we are interested by integration tests, I believe this one is well done: 
https://github.com/tbroyer/gradle-incap-helper/commit/2209bde0761dd30b4d45a943a97e2686650d343b