### PR TITLE
allow androidx projects to compile. Solves issue #230

### DIFF
--- a/dart-processor/build.gradle
+++ b/dart-processor/build.gradle
@@ -11,11 +11,12 @@ dependencies {
     implementation project(':dart')
     implementation deps.javapoet
     implementation deps.parceler.runtime
-    implementation deps.android.runtime
+    compileOnly deps.android.runtime
 
     testImplementation files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
     testImplementation deps.junit
     testImplementation deps.compiletesting
     testImplementation deps.truth
     testImplementation deps.fest
+    testImplementation deps.android.runtime
 }

--- a/henson-plugin/src/main/resources/build.properties
+++ b/henson-plugin/src/main/resources/build.properties
@@ -1,2 +1,2 @@
-#Fri Jan 11 15:08:30 PST 2019
+#Tue Jan 15 08:57:03 PST 2019
 dart.version=3.1.1-SNAPSHOT

--- a/henson-processor/build.gradle
+++ b/henson-processor/build.gradle
@@ -11,11 +11,12 @@ dependencies {
     implementation project(':henson')
     implementation deps.javapoet
     implementation deps.parceler.runtime
-    implementation deps.android.runtime
+    compileOnly deps.android.runtime
 
     testImplementation files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
     testImplementation deps.junit
     testImplementation deps.compiletesting
     testImplementation deps.truth
     testImplementation deps.fest
+    testImplementation deps.android.runtime
 }

--- a/henson-processor/src/main/java/dart/henson/processor/IntentBuilderGenerator.java
+++ b/henson-processor/src/main/java/dart/henson/processor/IntentBuilderGenerator.java
@@ -21,7 +21,6 @@ import static com.squareup.javapoet.ClassName.get;
 import static dart.common.util.ExtraBindingTargetUtil.BUNDLE_BUILDER_SUFFIX;
 import static dart.common.util.ExtraBindingTargetUtil.NEXT_STATE_METHOD;
 
-import android.content.Intent;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -103,8 +102,8 @@ public class IntentBuilderGenerator extends BaseGenerator {
 
     initialStateGetterForHensonBuilder.addStatement(
         "final $T intent = new $T(context, getClassDynamically($S))",
-        Intent.class,
-        Intent.class,
+        ClassName.get("android.content", "Intent"),
+        ClassName.get("android.content", "Intent"),
         target.getFQN());
     initialStateGetterForHensonBuilder.addStatement(
         "final $T bundler = $T.create()", Bundler.class, Bundler.class);


### PR DESCRIPTION
We had a few issues mentioned in #230. 

The migration to android x required all android artifacts to be removed from annotation processor path by dependent projects.

To resolve this:
* the android jar from maven central has been scoped as compileOnly
* re added to testImplementation when needed
* the only android class that the processors were using was android.content.Intent, I used a symolb of the class name instead.