### PR TITLE
Cast FileCollectionInternal as parameter of UnionFileCollection to support Gradle 6.6.1 

### DIFF
--- a/henson-plugin/src/main/java/dart/henson/plugin/internal/GenerateHensonNavigatorTask.java
+++ b/henson-plugin/src/main/java/dart/henson/plugin/internal/GenerateHensonNavigatorTask.java
@@ -39,6 +39,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.tasks.CacheableTask;
@@ -95,9 +96,9 @@ public class GenerateHensonNavigatorTask extends DefaultTask {
     TaskProvider<JavaCompile> javaCompiler = variant.getJavaCompileProvider();
     FileCollection variantCompileClasspath = getJarDependencies();
     FileCollection uft =
-        new UnionFileCollection(
-            javaCompiler.get().getSource(), project.fileTree(destinationFolder));
-    javaCompiler.get().setSource(uft);
+                new UnionFileCollection(
+                        (FileCollectionInternal) javaCompiler.get().getSource(), (FileCollectionInternal) project.fileTree(destinationFolder));
+       javaCompiler.get().setSource(uft);
     logger.debug("Analyzing configuration: " + variantCompileClasspath.getFiles());
     Set<String> targetActivities = new HashSet<>();
     Streams.stream(variantCompileClasspath)


### PR DESCRIPTION
The latest version of gradle 6.6.1 requires FileCollectionInternal class on UnionFileCollection param.